### PR TITLE
Fix for spaces in front of code blocks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,9 @@
 markdown: kramdown
+highlighter: rouge
 
 kramdown:
   input: GFM
   syntax_highlighter: rouge
-
-highlighter: rouge
 
 # ----
 # Site


### PR DESCRIPTION
Although seemingly minuscule, rearranging the order of options in the `_config.yml` seems to fix a bug where spaces appear at the front of each line in a codeblock.