### PR TITLE
Make link for current page in sidebar more distinct

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -274,6 +274,7 @@ nav > ul {
 	> a:active,
 	> a:hover {
 		color: #111;
+		font-weight: bold;
 	}
 
 	&.top-level > a {


### PR DESCRIPTION
Right now, it's hard to tell what page you're on in the sidebar (especially if you scroll it). This should make it more visually distinctive by bolding the link. This does not affect the styling on the parent element within the sidebar.