### PR TITLE
Add collapsable sidebar of top links

### DIFF
--- a/_docs/developer/index.md
+++ b/_docs/developer/index.md
@@ -1,5 +1,6 @@
 ---
 title: Developer
+permalink: /developer
 ---
 
 As a developer, you'll need to set up the full system on your own

--- a/_docs/grader/index.md
+++ b/_docs/grader/index.md
@@ -1,5 +1,6 @@
 ---
 title: TA or Grader
+permalink: /grader
 ---
 
 ### TA Navigation Page

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Welcome
+permalink: /index
 ---
 
 [Submitty](http://submitty.org) is an open source programming

--- a/_docs/instructor/index.md
+++ b/_docs/instructor/index.md
@@ -1,5 +1,6 @@
 ---
 title: Instructor
+permalink: /instructor
 ---
 
 ### Instructor Navigation Page

--- a/_docs/student/index.md
+++ b/_docs/student/index.md
@@ -1,5 +1,6 @@
 ---
 title: Student
+permalink: /student
 ---
 
 [How do I login to Submitty?](login)

--- a/_docs/sysadmin/index.md
+++ b/_docs/sysadmin/index.md
@@ -1,5 +1,6 @@
 ---
 title: System Administrator
+permalink: /sysadmin
 ---
 
 To create a production server, you'll need a machine with Ubuntu 16.04

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -95,13 +95,19 @@
                             {% if child.children %}
                             <ul>
                                 {% for subchild in child.children %}
-                                <li class="nav-item inner">
+                                {% assign subchild_link = subchild.name | replace: ' ', '_' | downcase %}
+                                {% if subchild.link %}
+                                    {% assign subchild_link = subchild.link %}
+                                {% endif %}
+                                {% assign full_subchild_link = full_child_link | append: '/' | append: subchild_link %}
+                                {% assign subchild_extra = '' %}
+                                {% if full_subchild_link == page.url %}
+                                    {% assign subchild_extra = subchild_extra | append: ' current' %}
+                                {% endif %}
+                                <li class="nav-item inner {{ subchild_extra }}">
                                     {% assign subchild_link = subchild.name | replace: ' ', '_' | downcase %}
                                     {% if subchild.link != false %}
-                                        {% if subchild.link %}
-                                            {% assign subchild_link = subchild.link %}
-                                        {% endif %}
-                                    <a href="{{ top_link }}/{{ child_link }}/{{ subchild_link }}">
+                                    <a href="{{ full_subchild_link }}">
                                     {% endif %}
                                     {{ subchild.name }}
                                     {% if subchild.link != false %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,44 +27,7 @@
                 ga('send', 'pageview');
             </script>
         {% endif %}
-        <script>
-            // This function moves the window to the specified #hash (if one exists)
-            // as well as applies the 'current' class to the sidebar link for the
-            // page we're currently on and scrolls sidebar to its position.
-            document.onreadystatechange = function() {
-                if (this.readyState === "complete") {
-                    var url = window.location.href;
-                    console.log(url);
-                    if (url.indexOf('#') !== -1) {
-                        var oldHash = url.substr(url.indexOf('#'));
-                        location.hash = '';
-                        location.hash = oldHash;
-                        url = url.substr(0, url.indexOf('#'));
-                    }
-                    console.log(url);
-                    var elems = document.getElementsByClassName('nav-item');
-                    for (var i = 0; i < elems.length; i++) {
-                        if (elems[i].children[0].href === url) {
-                            elems[i].className += " current";
-                            var el = elems[i];
-                            do {
-                                if (el.classList.contains('top-level')){
-                                    var topLevel = el;
-                                }
-                            } while (el = el.parentElement);
-                            if (!topLevel) break;
-                            offsetToScroll = topLevel.offsetTop;
-                            var sidebar = document.getElementsByClassName('main-nav');
-                            if (sidebar.length > 0){
-                                sidebar = sidebar[0];
-                            }
-                            sidebar.scrollTop = offsetToScroll;
-                            break;
-                        }
-                    }
-                }
-            }
-        </script>
+        <script type="text/javascript" src="{{ site.baseurl }}/scripts/main.js"></script>
     </head>
 
     <body>
@@ -81,28 +44,45 @@
             </form>
             <ul>
                 {% for entry in site.data.links %}
-                <li class="nav-item top-level">
-                    {% assign top_link = entry.name | replace: ' ', '_' | downcase %}
+                {% assign top_link = entry.name | replace: ' ', '_' | downcase %}
+                {% assign extra_class = "" %}
+                
+                {% if entry.link %}
+                    {% assign top_link = entry.link %}
+                {% endif %}
+                {% assign top_link = "/" | append: top_link %}
+                {% if page.url contains top_link %}
+                    {% assign extra_class = extra_class | append: ' open' %}
+                {% endif %}
+                {% if entry.children %}
+                    {% assign extra_class = extra_class | append: ' has-children' %}
+                {% else %}
+                    {% assign extra_class = extra_class | append: ' no-children' %}
+                {% endif %}
+                <li class="nav-item top-level {{ extra_class }}">
                     {% if entry.link != false %}
-                        {% if entry.link %}
-                            {% assign top_link = entry.link %}
-                        {% endif %}
-                    <a href="/{{ top_link }}">
+                    <a href="{{ top_link }}">
                     {% endif %}
+                    <i class="nav-arrow"></i>
                     {{ entry.name }}
                     {% if entry.link != false %}
                     </a>
                     {% endif %}
                     {% if entry.children %}
-                    <ul>
+                    <ul class="inner-nav">
                         {% for child in entry.children %}
-                        <li class="nav-item">
                             {% assign child_link = child.name | replace: ' ', '_' | downcase %}
+                            {% if child.link %}
+                                {% assign child_link = child.link %}
+                            {% endif %}
+                            {% assign full_child_link = top_link | append: '/' | append: child_link %}
+                            {% assign inner_extra = '' %}
+                            {% if full_child_link == page.url %}
+                                {% assign inner_extra = inner_extra | append: ' current' %}
+                            {% endif %}
+                        <li class="nav-item {{ inner_extra }}">
                             {% if child.link != false %}
-                                {% if child.link %}
-                                    {% assign child_link = child.link %}
-                                {% endif %}
-                            <a href="/{{ top_link }}/{{ child_link }}">
+                            <a href="{{ full_child_link }}">
                             {% else %}
                             <div>
                             {% endif %}
@@ -121,7 +101,7 @@
                                         {% if subchild.link %}
                                             {% assign subchild_link = subchild.link %}
                                         {% endif %}
-                                    <a href="/{{ top_link }}/{{ child_link }}/{{ subchild_link }}">
+                                    <a href="{{ top_link }}/{{ child_link }}/{{ subchild_link }}">
                                     {% endif %}
                                     {{ subchild.name }}
                                     {% if subchild.link != false %}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -130,6 +130,8 @@ header {
 			height: $emblem-size;
 			//width: $emblem-size;
 			margin-right: $space - 5;
+			margin-left: -10px;
+			max-width: none;
 		}
 	}
 
@@ -280,7 +282,7 @@ nav > ul {
 	&.top-level > a {
 		line-height: 1.5;
 		font-weight: 600;
-		padding-left: $space;
+		//padding-left: $space;
 	}
 
         &.inner > a {

--- a/css/main.scss
+++ b/css/main.scss
@@ -36,3 +36,65 @@ $full-width-break: $nav-width + ($space * 4) + $content-max-width;
 header.main-nav > ul {
   margin-bottom: 30px;
 }
+
+.top-level > .inner-nav {
+  display: none;
+}
+
+.top-level.open > .inner-nav {
+  display: block;
+}
+
+.nav-arrow {
+  display: none;
+  position: relative;
+  margin-left: -32px;
+  width: 12px;
+}
+
+.has-children .nav-arrow {
+  display: inline-block;
+}
+
+.nav-arrow:before {
+  /*
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  */
+  display: block;
+  content: "";
+  margin: -.25em 0 0 -.4em;
+
+  width: .5em;
+  height: .5em;
+  border-right: .15em solid #3f4657;
+  border-top: .15em solid #3f4657;
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
+  -webkit-transition-duration: .3s;
+  transition-duration: .3s;
+}
+
+.nav-item.open .nav-arrow:before {
+  margin-left: -.25em;
+  -webkit-transform: rotate(135deg);
+  transform: rotate(135deg);
+}
+
+.top-level.no-children {
+  margin-left: -16px;
+}
+
+.content h1 svg.anchor,
+.content h2 svg.anchor,
+.content h3 svg.anchor {
+  margin-left: 10px;
+  visibility: hidden;
+}
+
+.content h1:hover svg.anchor,
+.content h2:hover svg.anchor,
+.content h3:hover svg.anchor {
+  visibility: visible;
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,11 +1,10 @@
-// This function moves the window to the specified #hash (if one exists)
-// as well as applies the 'current' class to the sidebar link for the
-// page we're currently on and scrolls sidebar to its position.
 document.addEventListener('DOMContentLoaded', function() {
   var element = null;
+
+  // Set up the collapse/expand feature of the arrows that sit next to
+  // the sidebar links
   for (element of document.getElementsByClassName('nav-arrow')) {
     element.addEventListener('click', function(event) {
-      console.log('test');
       event.stopPropagation();
       event.preventDefault();
       let parent = event.target;
@@ -16,9 +15,8 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  /*
-  <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
-  */
+  // Add anchor svg next to all headers within the content div of our page to make it easier to
+  // get the hash of that element so that you can more easily copy/paste links to specific sections
   var header;
   for (header of ['h1', 'h2', 'h3']) {
     for (element of document.getElementsByClassName('content')[0].getElementsByTagName(header)) {
@@ -29,6 +27,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
 // Wait for all CSS/JS to be loaded in, which is useful given how Jekyll works on Github pages
 window.addEventListener('load', function() {
+  // If there is a hash tag in the URL, scroll to it via JS as Jekyll breaks the built-in browser
+  // autoscroll feature with how it serves up ages.
   var url = window.location.href;
   if (url.indexOf('#') !== -1) {
     var oldHash = url.substr(url.indexOf('#'));
@@ -37,5 +37,7 @@ window.addEventListener('load', function() {
     url = url.substr(0, url.indexOf('#'));
   }
 
+  // Scroll the sidebar to the element marked as "current", useful if it's out of the browser's
+  // viewport
   document.getElementsByClassName('current')[0].scrollIntoView();
 });

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,0 +1,41 @@
+// This function moves the window to the specified #hash (if one exists)
+// as well as applies the 'current' class to the sidebar link for the
+// page we're currently on and scrolls sidebar to its position.
+document.addEventListener('DOMContentLoaded', function() {
+  var element = null;
+  for (element of document.getElementsByClassName('nav-arrow')) {
+    element.addEventListener('click', function(event) {
+      console.log('test');
+      event.stopPropagation();
+      event.preventDefault();
+      let parent = event.target;
+      while (parent.tagName.toLowerCase() !== 'li') {
+        parent = parent.parentElement;
+      }
+      parent.classList.toggle('open')
+    });
+  }
+
+  /*
+  <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>
+  */
+  var header;
+  for (header of ['h1', 'h2', 'h3']) {
+    for (element of document.getElementsByClassName('content')[0].getElementsByTagName(header)) {
+      element.insertAdjacentHTML('beforeend', '<a href="#' + element.getAttribute('id') + '"><svg class="anchor" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>');
+    }
+  }
+});
+
+// Wait for all CSS/JS to be loaded in, which is useful given how Jekyll works on Github pages
+window.addEventListener('load', function() {
+  var url = window.location.href;
+  if (url.indexOf('#') !== -1) {
+    var oldHash = url.substr(url.indexOf('#'));
+    location.hash = '';
+    location.hash = oldHash;
+    url = url.substr(0, url.indexOf('#'));
+  }
+
+  document.getElementsByClassName('current')[0].scrollIntoView();
+});


### PR DESCRIPTION
The next step of improving the sidebar readability.

If you're within a section, then the section is expanded, else it is collapsed. If you click the arrow next to the top-link that has children, it will expand/collapse the section as appropriate.

* Moves the setting of the current tag into the HTML layout which is quicker/better than using javascript
* Move the "auto scroll" for the sidebar into 'load' eventListener (which fires after all CSS and such is loaded, unlike DOMContentLoaded which fires just when all DOM is inserted) to improve reliability of this feature
* Adds anchor svg on header tags within content that show up when hovering over the header which when clicked presents you the hash of the element into your browser window making it easier to copy/paste those elements.

Screenshot of the menu:
![screenshot 2018-08-18 17 07 38](https://user-images.githubusercontent.com/1845314/44304176-38eeb000-a309-11e8-96ad-a9ced54cba77.png)

Screenshot of link icon on headers:
![screenshot 2018-08-18 17 24 53](https://user-images.githubusercontent.com/1845314/44304256-a26fbe00-a30b-11e8-96df-7ae9e94a404e.png)
