### PR TITLE
Updating possible values for testcase type

### DIFF
--- a/_docs/instructor/assignment_configuration.md
+++ b/_docs/instructor/assignment_configuration.md
@@ -260,8 +260,8 @@ executables.
 
 * **field:** ``"type"``  
   **type:** _string_   
-  **value:** ``"compilation"``, ``"file_check"``, or ``"execution"``  
-  **default value:** ``"execution"``  
+  **value:** ``"Compilation"``, ``"FileCheck"``, or ``"Execution"``  
+  **default value:** ``"Execution"``  
 
   _Each test case has a type, the type dictates whether actions are
   necessary for that test case during the different phases of


### PR DESCRIPTION
The instructor documentation reflects that possible values for a testcase type include "compilation", "file_check", or "execution".

However, the source code reflects possible values of "Compilation", "FileCheck", or "Execution", with "Execution" being the default value.