### PR TITLE
Correct the category of Log Files

### DIFF
--- a/_docs/instructor/log_files.md
+++ b/_docs/instructor/log_files.md
@@ -1,6 +1,6 @@
 ---
 title: Log Files
-category: Developer
+category: Instructor
 order: 4
 ---
 


### PR DESCRIPTION
Now log_files.md is put under "Instructor" category while the category shown in the [webpage](https://submitty.org/instructor/log_files) is "Developer".