### PR TITLE
Show doc for Discussion Forum

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -60,6 +60,8 @@
       link: student_photos
     - name: Silent Grade Editing
       link: silent_editing
+    - name: Discussion Forum
+      link: forum
 
 - name: System Administrator
   link: sysadmin


### PR DESCRIPTION
I found the link to [Discussion Forum](https://submitty.org/instructor/forum) in Gagan Kumar's GSoC report, but I can not find it in the sidebar. Not sure if it is intentionally hidden though.