### PR TITLE
Include installation of ChromeDriver on Linux

### DIFF
--- a/_docs/developer/end_to_end_tests.md
+++ b/_docs/developer/end_to_end_tests.md
@@ -29,6 +29,14 @@ homebrew:
 ```
 brew cask install chromedriver
 ```
+For Linux (64-bit), use:
+```
+wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip && \
+unzip chromedriver_linux64.zip && \
+sudo mv chromedriver /usr/bin/chromedriver && \
+sudo chown root:root /usr/bin/chromedriver && \
+sudo chmod +x /usr/bin/chromedriver
+```
 
 ---
 

--- a/_docs/developer/end_to_end_tests.md
+++ b/_docs/developer/end_to_end_tests.md
@@ -24,19 +24,30 @@ a different browser stack by modifying the `setUpClass` method in
 You'll need to install the
 [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/getting-started)
 to allow selenium access to utilize Chrome. You can either download the binary
-from the above site or use your OS' package manager, e.g. for Mac, use
-homebrew:
+from the above site or use your OS' package manager. For convinence, we list
+some options for installation on Mac, Linux, and Windows below. For any step
+that lists `<CHROMEDRIVER_VERSION>`, you will have to determine the appropriate
+version using the [Version Selection](https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection)
+page from the above link.
+
+For Mac, using homebrew:
 ```
 brew cask install chromedriver
 ```
-For Linux (64-bit), use:
+
+For Linux, use:
 ```
-wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip && \
+wget https://chromedriver.storage.googleapis.com/<CHROMEDRIVER_VERSION>/chromedriver_linux64.zip && \
 unzip chromedriver_linux64.zip && \
-sudo mv chromedriver /usr/bin/chromedriver && \
-sudo chown root:root /usr/bin/chromedriver && \
-sudo chmod +x /usr/bin/chromedriver
+sudo mv chromedriver /usr/local/bin/chromedriver && \
+sudo chown root:root /usr/local/bin/chromedriver && \
+sudo chmod +x /usr/local/bin/chromedriver
 ```
+
+For Windows, download the appropriate version and place it on your 
+[PATH](https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/).
+
+_NOTE_: You will need to make sure to keep chromedriver up-to-date as Chrome auto-updates itself.
 
 ---
 


### PR DESCRIPTION
Clear and concise documentation of the installation of ChromeDriver is not available on the website linked for ChromeDriver. I was using it for the first time and got fairly confused, having use an external blog to understand its installation process. It will help users to have it here. They keep changing the version numbers and there's no 'latest' release directory, thus the user may have to write the latest download's URL/version number himself.