### PR TITLE
Incorrect Directory for autograding_workers.json

### DIFF
--- a/_docs/developer/automated_grading.md
+++ b/_docs/developer/automated_grading.md
@@ -37,7 +37,7 @@ shipper processes on the primary machine and the worker manager will
 launch 5 worker processes on the primary machine.  To adjust this
 number:
 
-1. As root, edit the `/usr/local/submitty/.setup/autograding_workers.json`
+1. As root, edit the `/usr/local/submitty/config/autograding_workers.json`
    settings and edit the `num_autograding_workers` field as desired:
 
    ```


### PR DESCRIPTION
### Files and folder in config and .setup folders
Setup folder contains following files and folder:-
![Screenshot from 2019-05-22 15-14-10](https://user-images.githubusercontent.com/42701709/58164880-4d9b1280-7ca4-11e9-9f67-2f6a810894c9.png)
Config folder contains following files and folder:-
![Screenshot from 2019-05-22 15-13-39](https://user-images.githubusercontent.com/42701709/58164882-4d9b1280-7ca4-11e9-8567-feec2d2eb899.png)

### Error
autograding_workers.json is contained only in config and path described in documentation shows that it is contained in .setup folder
