### PR TITLE
Modify the wording of up migration re-running

### DIFF
--- a/_docs/developer/migrations.md
+++ b/_docs/developer/migrations.md
@@ -162,6 +162,7 @@ directory or file structure:
     in the future. Your `down` function may be empty.
 
     Thus, it is important to ensure that the `up` migration can be
-    re-run.  For example, your `up` function should not crash on adding the
-    column if the column already exists.
+    re-run after the corresponding `down` migration is run.  For example, 
+    your `up` function should not crash on adding the column if the column
+    already exists.
 


### PR DESCRIPTION
> Thus, it is important to ensure that the `up` migration can be re-run.

I thought it meant: We should ensure that `up-up-up-up-up` is successful.

However, according to Matt at https://github.com/Submitty/Submitty/issues/3769#issuecomment-498909911, it actually means: We should ensure that `up-down-up-down-up` is successful.