### PR TITLE
Alternative to vagrant ssh to be included in submitty install file

### DIFF
--- a/_docs/developer/vm_install_using_vagrant.md
+++ b/_docs/developer/vm_install_using_vagrant.md
@@ -224,6 +224,27 @@ operating system.
 
     You will connect to the VM as the `root` user.
 
+    If `vagrant ssh` asks for a password for the root@127.0.0.1 user and "vagrant" without the quotation marks does not work, look at the vagrant ssh config file and make note of the hostname and port.
+
+    ```sh
+    vagrant ssh-config
+    ```
+
+    Then directly ssh into the VM by
+
+    ```sh
+    ssh vagrant@hostname -p port
+    ```
+
+    If it asks for password, it should be "vagrant"
+    and then 
+
+    ```sh
+    sudo su
+    ```
+
+    to login as the root user. You should then see you are logged in as root@vagrant.
+
 11. The following users exist on the VM:
 
     | user | password | role |


### PR DESCRIPTION
Changed vm_install_using_vagrant.md file to include am alternative way to ssh into vm when vagrant ssh asks for root password.