### PR TITLE
Updated instructions for installing and running php unit tests

### DIFF
--- a/_docs/developer/php_unit_tests.md
+++ b/_docs/developer/php_unit_tests.md
@@ -53,7 +53,8 @@ missing some packages.
 `curl_init()` errors can be solved by checking if `php-curl` is installed
 `ZipArchive` errors can be solved by checking if `php-zip` is installed
 `DataBase driver missing` can be solved by checking if `php-sqlite` is installed.
-You can install all 3 on Ubuntu/Debain with:
+You can install all 3 on Ubuntu/Debian with for PHP 7.2, for other versions
+change the `7.2` to the version of PHP you have locally installed:
 ```
 sudo apt-get -y install -q php7.2-cli php-curl php-zip php7.2-mbstring php7.2-xml php7.2-xdebug php7.2-sqlite3
 ```

--- a/_docs/developer/php_unit_tests.md
+++ b/_docs/developer/php_unit_tests.md
@@ -5,16 +5,18 @@ order: 8
 ---
 
 These are general details and instructions for testing the PHP code
-(both Unit and End-to-End). OS specific instructions are below.
+with PHPUnit. OS specific instructions are below.
 
-The primary method of testing for the PHP code is _Unit Testing_ (we
-also do End-to-End testing, but that is covered in a different
-section). These tests require that you have
-[PHPUnit](https://phpunit.de/) on your system.
+The primary method of testing for the PHP code is _Unit Testing_, along
+with [End to End Tests](end_to_end_tests.md)
+
+These tests require that you have
+[PHPUnit](https://phpunit.de/) on your system. PHP 7.2 or PHP 7.3 is 
+required for the version of PHPUnit Submitty uses.
 
 You can either get the .phar files for it or much more easily use
-[Composer](https://getcomposer.org/) to handle this for you. From the
-root of the repository, simply run:
+[Composer](https://getcomposer.org/) to handle this for you. From 
+`Submitty/site` run:
 
 ```
 composer install
@@ -23,17 +25,34 @@ composer install
 This will download PHPUnit and PHPUnit-Selenium to the local machine
 and make it available via the vendor directory.
 
-Note: If you're using PHP 5.5, you'll first need to run the command
-
+If composer fails, you may be missing some required PHP modules.
+php-cli, php-mbstring, and php-xml should be installed already. 
+On Ubuntu/Debian these can be installed by:
 ```
-cp composer_55.json composer.json
+sudo apt-get install php7.X-cli
+sudo apt-get install php7.X-mbstring
+sudo apt-get install php7.X-xml
 ```
+Replace `php-7.X` with the version of PHP installed locally. For example
+if you have PHP 7.2 then your command would like: `sudo apt-get install php7.2-cli`
 
-From there, to run the unit test suite, you can run from the root:
+You will also need to have [Xdebug](https://xdebug.org/) locally installed.
+On Ubuntu/Debian you can install by:
+```
+sudo apt-get install php7.X-xdebug
+``` 
+
+From there, to run the unit test suite, you can run from `Submitty/site`:
 
 ```
 vendor/bin/phpunit --configuration tests/phpunit.xml
 ```
+If you see any errors running PHPUnit for the first time, you may be 
+missing some packages. 
+
+`curl_init()` errors can be solved by checking if `php-curl` is installed
+`ZipArchive` errors can be solved by checking if `php-zip` is installed
+`DataBase driver missing` can be solved by checking if `php-sqlite` is installed.
 
 ## Mac Installation
 

--- a/_docs/developer/php_unit_tests.md
+++ b/_docs/developer/php_unit_tests.md
@@ -22,7 +22,7 @@ You can either get the .phar files for it or much more easily use
 composer install
 ```
 
-This will download PHPUnit and PHPUnit-Selenium to the local machine
+This will download PHPUnit to the local machine
 and make it available via the vendor directory.
 
 If composer fails, you may be missing some required PHP modules.
@@ -53,7 +53,10 @@ missing some packages.
 `curl_init()` errors can be solved by checking if `php-curl` is installed
 `ZipArchive` errors can be solved by checking if `php-zip` is installed
 `DataBase driver missing` can be solved by checking if `php-sqlite` is installed.
-
+You can install all 3 on Ubuntu/Debain with:
+```
+sudo apt-get -y install -q php7.2-cli php-curl php-zip php7.2-mbstring php7.2-xml php7.2-xdebug php7.2-sqlite3
+```
 ## Mac Installation
 
 If using a Mac computer, the following commands can be run to set


### PR DESCRIPTION
Went through the steps to get php unit tests working on a clean install (on debian 9 'stretch') 
Changes:
PHPUnit refused to work on anything other than 7.2 or 7.2 so thats updated in the docs
Submitty tests moved from the root directory to Submitty/site
Composer couldn't run without some packages which are now listed
Xdebug is required as a code coverage driver 
Added some packages if PHPUnit fails on the first time