### PR TITLE
Documentation for Changing Site Time in Vagrant

### DIFF
--- a/_docs/developer/development_instructions.md
+++ b/_docs/developer/development_instructions.md
@@ -207,6 +207,28 @@ Please also see [Installation Version Notes](../../sysadmin/version_notes)
 
 ---
 
+* If you need to test time and/or date dependent elements, you can change it in the vagrant machine so 
+you don't have to wait.
+To remove the syncing and set your own time:
+
+    ```
+    sudo systemctl disable ntp
+    timedatectl set-ntp 0
+    sudo date -s "<year>-<month>-<day> <hour>:<minute>:<seconds>
+    ```
+To check the date, helpful to make sure the date and time you set has stuck:
+
+    ```
+    date
+    ``` 
+To sync back with the current time:
+
+    ```
+    sudo systemctl enable ntp
+    timedatectl set-ntp 1
+    ```
+---
+
 * If the JavaScript files have changed and there are errors or you do not see the changes then you may need to clear your browser's cache
 
 


### PR DESCRIPTION
Added documentation to help developers figure out how to pause and unpause the time sync and change it to whatever they want.