### PR TITLE
[Documentation:Testing] expand docs for writing php unit tests

### DIFF
--- a/_docs/developer/php_unit_tests/writing_unit_tests.md
+++ b/_docs/developer/php_unit_tests/writing_unit_tests.md
@@ -94,7 +94,6 @@ to be used within a group of tests. This is known state is called a _fixture_
 for the test, and they can be defined around each test, or around all tests in
 a class.
 
-
 To setup a fixture that are run around each individual test, you can use the
 `setUp` and `tearDown` functions. These are defined by doing:
 

--- a/_docs/developer/php_unit_tests/writing_unit_tests.md
+++ b/_docs/developer/php_unit_tests/writing_unit_tests.md
@@ -20,9 +20,10 @@ functions in the tester class can be private, public, or protected and they will
 ignored as long as they do *not* begin with the word "test". For example, `createMockUser`
 will not be run, while `testUploadOneBucket` would be.
 
-Each test method should make an assertion, such as `assertTrue` or `assertFalse`,
-otherwise the test will get labeled as a "risky test" by PHPUnit. You can find a list
-of all PHPUnit assertions [here](https://phpunit.readthedocs.io/en/latest/assertions.html).
+Each test method should make an assertion, such as `assertTrue`, `assertFalse`,
+`assertSame`, otherwise the test will get labeled as a "risky test" by PHPUnit. You can
+find a list of all PHPUnit assertions
+[here](https://phpunit.readthedocs.io/en/latest/assertions.html).
 
 Most tests for controllers in Submitty assert against the JSON response sent back, the
 specifications for Submitty's JSON responses can be found [here](../json_responses).
@@ -33,6 +34,58 @@ Here are some example Unit tests:
 - [AuthenticationControllerTester.php](https://github.com/Submitty/Submitty/blob/master/site/tests/app/controllers/AuthenticationControllerTester.php)
 - [AbstractDatabaseTester](https://github.com/Submitty/Submitty/blob/master/site/tests/app/libraries/database/AbstractDatabaseTester.php)
 - [CourseTester.php](https://github.com/Submitty/Submitty/blob/master/site/tests/app/models/CourseTester.php)
+
+## Parameterized Testing
+
+Sometimes, while writing tests, you may find yourself wanting to test the same piece of
+code, but just needing to change one variable. To handle this, you ca use the concept
+of _Paramterized Tests_. To do this, you will add a _Data Provider_ to your test
+function. The data provider is a function that returns an array or generator that is
+then passed to your test function. The test function is linked to the data provider, by
+adding a `@dataProvider` annotation. The data provider function should return an array of
+arrays where each inner array is the list of arguments that will be passed to your test
+function. Here is an example of this all put together:
+
+```php
+public function additionProvider() {
+    return [
+        [0, 0, 0],
+        [0, 1, 1],
+        [1, 0, 1],
+        [1, 2, 3]
+    ];
+}
+
+/**
+ * @dataProvider additionProvider
+ */
+public function testAddition($num_1, $num_2, $expected) {
+    $this->assertSame($expected, $num_1 + $num_2);
+}
+```
+
+As mentioned above, you can use
+[Generators](https://www.php.net/manual/en/language.generators.overview.php)
+for the return of a data provider, which helps to minimize memory usage
+if constructing larger objects. The above example using generators would look like:
+
+```php
+public function additionProvider() {
+    yield [0, 0, 0];
+    yield [0, 1, 1];
+    yield [1, 0, 1];
+    yield [1, 2, 3];
+}
+
+/**
+ * @dataProvider additionProvider
+ */
+public function testAddition($num_1, $num_2, $expected) {
+    $this->assertSame($expected, $num_1 + $num_2);
+}
+```
+
+For more details, see [PHPUnit Data Providers](https://phpunit.readthedocs.io/en/latest/writing-tests-for-phpunit.html#data-providers).
 
 ## Test Setup/Teardown
 

--- a/_docs/developer/php_unit_tests/writing_unit_tests.md
+++ b/_docs/developer/php_unit_tests/writing_unit_tests.md
@@ -221,6 +221,13 @@ running `--filter testFoo` will run them both. Alternatively, you can also direc
 `vendor/bin/phpunit tests/app/authentication/DatabaseAuthenticationTester.php` will run
 only the test methods in `DatabaseAuthenticationTester.php`.
 
+The two concepts above can be combined to run a specific test function in a specific
+class by doing:
+
+```bash
+vendor/bin/phpunit -c tests/phpunit.xml --filter testFunction tests/app/path/to/TestClass.php
+```
+
 You can pass in the `--debug` flag when using PHPUnit to see PHP output, this can be
 useful when writing new tests.
 


### PR DESCRIPTION
Expands existing documentation for writing PHP unit tests adding some more details, and clarifying wording in some places. I've also updated all links to PHPUnit docs to use `latest` which should always point to the version we currently use(which is `8.3` right now).

New sections:
* Mocks / Test Doubles for classes and PHP builtin functions
* Data Providers

Added words for:
* That technically, need to expand off `\PHPUnit\Framework\TestCase`, but that `BaseUnitTest` may be beneficial to use (people should not cargo cult using it if they do not need it).
* description of class level setup and teardown
* the `--filter` flag for running specific test functions or classes
* requirements for generating code coverage (xdebug or pcov)