### PR TITLE
update docs to reference new install script

### DIFF
--- a/_docs/developer/autograding_tests.md
+++ b/_docs/developer/autograding_tests.md
@@ -13,12 +13,11 @@ message) any test suite failures.
 
 To start with a fresh grading library install and build, and to run
 the full test suite, pass the optional "clean" and "test" arguments to
-the `INSTALL_SUBMITTY.sh` script:
+the `install_submitty.sh` script:
 
-``` 
-sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh clean test 
 ```
-
+sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh clean test
+```
 
 
 ### Run Only Select Test Suite Modules
@@ -27,18 +26,18 @@ As you are debugging and fixing grading library code and or editing or
 writing new test suite modules, you can run one or more select test
 modules from the test suite, pass those as additional arguments.
 
-``` 
-sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh test test_1 test_5 
+```
+sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh test test_1 test_5
 ```
 
 ### Run Only Select Test Cases
 
-If you are currently only focusing on one test case, you can specify it by 
+If you are currently only focusing on one test case, you can specify it by
 putting the module name, a period, and then the test name as an argument
 to test suite. Capitalization doesn't matter for matching on the test name.
 
 ```
-sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh test test_1.test_name 
+sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh test test_1.test_name
 ```
 
 
@@ -75,15 +74,15 @@ to be checked against the results of running grading code.
 
 The modules of the autograding test suite are located in the repository:
 
-``` 
-REPOSITORY/tests/integrationTests/tests/TEST_MODULE_NAME 
+```
+REPOSITORY/tests/integrationTests/tests/TEST_MODULE_NAME
 ```
 
 
 The test suite installation process copies this directory tree to:
 
-``` 
-/usr/local/submitty/test_suite/integrationTests/tests/TEST_MODULE_NAME 
+```
+/usr/local/submitty/test_suite/integrationTests/tests/TEST_MODULE_NAME
 ```
 
 (WARNING: Do not edit the files in the installation directory since

--- a/_docs/developer/automated_grading.md
+++ b/_docs/developer/automated_grading.md
@@ -17,7 +17,7 @@ same machine.  In more complex use cases Submitty can be configured to
 ship jobs from the *primary* machine to one or more *worker* machines.
 This can be useful to manage very large numbers of submissions near
 deadlines, or to facilitate use of specific hardware or extra
-resources for certain assignments.  
+resources for certain assignments.
 
 Automated grading of multiple homeworks can be done in parallel.  The
 system administrator should adjust the Submitty configurations
@@ -54,7 +54,7 @@ number:
 2. Then re-install Submitty:
 
    ```
-   sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh
+   sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh
    ```
 
    _NOTE: If you delete the `autograding_workers.json` file and re-run
@@ -88,8 +88,8 @@ number:
 
    _NOTE: You may specify that no autograding should be done on the primary machine
    and instead ship all autograding tasks to the worker machines by specifying
-   `num_autograding_workers` to be zero for the `"primary"` machine._  
-   
+   `num_autograding_workers` to be zero for the `"primary"` machine._
+
 
 2. Setting up the worker machine(s):
 
@@ -97,7 +97,7 @@ number:
       for the worker machine.
 
       _TODO: Write these instructions._
-      
+
    2. Create the user account that will have access to send files from
       the primary machine to the worker machine.  In our example we
       name that user account `submitty`.  That user account must be in
@@ -115,7 +115,7 @@ number:
 3. Next, create homework assignment autograding configurations that
    specify jobs that should be shipped.  In your `config.json` file,
    add the `"required_capabilities"` field:
-  
+
    ```
    "required_capabilities" : "extra_ram"
    ```
@@ -131,7 +131,7 @@ number:
 
 ---
 
-## Debugging 
+## Debugging
 
 To debug new features for autograding, it can be helpful to run
 `submitty_autograding_shipper.py` and `submitty_autograding_worker.py`
@@ -172,7 +172,7 @@ To do this:
    sudo systemctl start submitty_autograding_shipper
    sudo systemctl start submitty_autograding_worker
    ```
-   
+
    or
 
    ```
@@ -187,7 +187,7 @@ To do this:
    sudo systemctl status submitty_autograding_worker
    ```
 
-_NOTE: When you re-run `sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh`, it will stop and
+_NOTE: When you re-run `sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh`, it will stop and
 restart the autograding shipper and worker if it is running.  (But it
 will not start the scheduler, if it is not currently running.)_
 
@@ -205,7 +205,7 @@ The following script will stop and restart all of the shippers &
 workers on the primary and worker machines, in the right order.
 
 ```
-sudo python3 /usr/local/submitty/sbin/restart_shipper_and_all_workers.py 
+sudo python3 /usr/local/submitty/sbin/restart_shipper_and_all_workers.py
 ```
 
 If one of the remote machines is not reachable, its use will be

--- a/_docs/developer/development_instructions.md
+++ b/_docs/developer/development_instructions.md
@@ -32,7 +32,7 @@ Please also see [Installation Version Notes](../../sysadmin/version_notes)
   vagrant destroy
   vagrant up
   ```
-  
+
   _NOTE: This process will take a bit of time (~30 minutes), and
   requires an internet connection.  It will delete any assignments
   you've uploaded to your VM installation.  And it will erase any
@@ -52,7 +52,7 @@ Please also see [Installation Version Notes](../../sysadmin/version_notes)
   ```
 
   If the vagrant box is not running, you would run the command:
-   
+
   ```
   vagrant up --provision
   ```
@@ -74,7 +74,7 @@ Please also see [Installation Version Notes](../../sysadmin/version_notes)
   And then re-install the submitty sources:
 
   ```
-  sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh clean
+  sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh clean
   ```
 
 ---
@@ -83,7 +83,7 @@ Please also see [Installation Version Notes](../../sysadmin/version_notes)
 * If you've changed the script to create a new course
   (`create_course.sh`), or the schema for the course database
   (`tables.sql`), we need to delete all courses, and recreate the
-  course databases, users, and sample submission uploads.  
+  course databases, users, and sample submission uploads.
 
   _NOTE: To avoid accidental use on the live server, the partial
   reset script first checks for the existence of a .vagrant folder._
@@ -96,7 +96,7 @@ Please also see [Installation Version Notes](../../sysadmin/version_notes)
 
   ```
   sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/bin/recreate_sample_courses.sh
-  ```   
+  ```
 
 
   If there are changes to the auxiliary Tutorial or AnalysisTools
@@ -108,32 +108,32 @@ Please also see [Installation Version Notes](../../sysadmin/version_notes)
 
 ---
 
-* If you've changed `INSTALL_SUBMITTY_HELPER.sh`, or if you've changed
+* If you've changed `install_submitty.sh`, or if you've changed
   any php/website files, re-install:
 
   ```
-  sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh
+  sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh
   ```
 
   _NOTE: This command uses rsync and should run reasonably fast since
   it's only copying and rebuilding what has changed._
 
   If you've moved/deleted files, it's good to do a fresh install of
-  the Submitty code:  
+  the Submitty code:
 
   ```
-  sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh clean
+  sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh clean
   ```
 
 ---
 
 * When working on code in the `site`, `bin`, or `sbin` directories, you can enable a watcher
   to re-install the code for those folders whenver something in them changes:
-  
+
   ```
   sudo python3 /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/bin/code_watcher.py
   ```
-  
+
   This can be run from outside the vagrant machine by doing:
   ```
   vagrant ssh -c "python3 /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/bin/code_watcher.py"
@@ -152,9 +152,9 @@ Please also see [Installation Version Notes](../../sysadmin/version_notes)
   In either case, run:
 
   ```
-  sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh clean
+  sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh clean
   ```
-  
+
   _NOTE: The `clean` argument is usually not necessary, and
   installation runs faster without it._
 
@@ -173,11 +173,11 @@ Please also see [Installation Version Notes](../../sysadmin/version_notes)
 
   And see also [Batch Regrade Homeworks](../instructor/batch_regrade_submissions)
 
-  For convenience, here are the commands to copy-paste to install, 
+  For convenience, here are the commands to copy-paste to install,
   build all courses, and regrade everything.
 
   ```
-  sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh clean && \
+  sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh clean && \
   for s in /var/local/submitty/courses/*/*; do c=`basename $s`; ${s}/BUILD_${c}.sh; done && \
   echo 'y' | /usr/local/submitty/bin/regrade.py /var/local/submitty/courses/ && \
   /usr/local/submitty/bin/grading_done.py
@@ -192,7 +192,7 @@ Please also see [Installation Version Notes](../../sysadmin/version_notes)
   ```
   /var/local/submitty/courses/s17/course_01/BUILD_course_01.sh
   ```
-   
+
   And see also [Batch Regrade Homeworks](../instructor/batch_regrade_submissions)
 
 ---
@@ -207,7 +207,7 @@ Please also see [Installation Version Notes](../../sysadmin/version_notes)
 
 ---
 
-* If you need to test time and/or date dependent elements, you can change it in the vagrant machine so 
+* If you need to test time and/or date dependent elements, you can change it in the vagrant machine so
 you don't have to wait.
 To remove the syncing and set your own time:
 
@@ -220,7 +220,7 @@ To check the date, helpful to make sure the date and time you set has stuck:
 
     ```
     date
-    ``` 
+    ```
 To sync back with the current time:
 
     ```
@@ -232,8 +232,8 @@ To sync back with the current time:
 * If the JavaScript files have changed and there are errors or you do not see the changes then you may need to clear your browser's cache
 
 
-   For Chrome: Choose the menu button, then "More tools", then "Clear browsing data"  
+   For Chrome: Choose the menu button, then "More tools", then "Clear browsing data"
 
-   For Firefox: Choose the menu button, then "Options", then "Advanced" in the "Network" tab under "Cached Web Content" click "Clear Now"  
+   For Firefox: Choose the menu button, then "Options", then "Advanced" in the "Network" tab under "Cached Web Content" click "Clear Now"
 
-   For Edge: Choose the Hub icon then the History icon, then "Clear all history"  
+   For Edge: Choose the Hub icon then the History icon, then "Clear all history"

--- a/_docs/developer/end_to_end_tests.md
+++ b/_docs/developer/end_to_end_tests.md
@@ -44,7 +44,7 @@ sudo chown root:root /usr/local/bin/chromedriver && \
 sudo chmod +x /usr/local/bin/chromedriver
 ```
 
-For Windows, download the appropriate version and place it on your 
+For Windows, download the appropriate version and place it on your
 [PATH](https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/).
 
 _NOTE_: You will need to make sure to keep chromedriver up-to-date as Chrome auto-updates itself.
@@ -57,7 +57,7 @@ To start the autograding systems run:
 ```
 sudo systemctl start submitty_autograding_shipper
 sudo systemctl start submitty_autograding_worker
-/usr/local/submitty/.setup/INSTALL_SUBMITTY.sh
+bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh
 ```
 
 See also: [Automated Grading](automated_grading)
@@ -73,7 +73,7 @@ python3 -m unittest
 **Note:** If you are using a non-standard installation of Submitty, you must
 edit `tests/e2e/base_testcase.py` and change the constant `TEST_URL`
 to reflect your installation's IP address.
-  
+
 To run an individual file or testcase, run:
 ```
 python3 -m unittest e2e.<module_name>.<ClassName>
@@ -86,22 +86,22 @@ python3 -m unittest e2e.test_login.TestLogin
 python3 -m unittest e2e.test_login.TestLogin.test_login
 ```
 
-To disable headless mode and view the browser while running a test, 
+To disable headless mode and view the browser while running a test,
 edit `tests/e2e/base_testcase.py` and comment out the line:
 ```
 self.options.add_argument('--headless')
 ```
 
-To slow down the tests for debugging, you can pause execution until 
+To slow down the tests for debugging, you can pause execution until
 you press Enter in the terminal. To do this, add the following line into your test:
 ```
 self.wait_user_input()
 ```
 
-Furthermore, Selenium's `wait.until` is another way to slow down tests. 
-It waits until an element loads or times out after a maximum time. This is 
-useful for both debugging and writing tests. For example, the following snippet 
-waits until an `h1` element containing "My Heading" appears and fails after 
+Furthermore, Selenium's `wait.until` is another way to slow down tests.
+It waits until an element loads or times out after a maximum time. This is
+useful for both debugging and writing tests. For example, the following snippet
+waits until an `h1` element containing "My Heading" appears and fails after
 10 secs if nothing shows up.
 
 ```

--- a/_docs/developer/jobs_daemon.md
+++ b/_docs/developer/jobs_daemon.md
@@ -52,5 +52,5 @@ existing one is edited, a job is placed in the queue.
    sudo systemctl status submitty_daemon_jobs_handler
    ```
 
-_NOTE: When you re-run `sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh`, it will stop and
+_NOTE: When you re-run `sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh`, it will stop and
 restart the jobs daemon if it is running._

--- a/_docs/developer/migrations.md
+++ b/_docs/developer/migrations.md
@@ -3,16 +3,16 @@ title: Migrations
 category: Developer
 ---
 
-We use [database migrations](https://en.wikipedia.org/wiki/Schema_migration) 
-to handle updating Submitty's databases, both in development and production, 
+We use [database migrations](https://en.wikipedia.org/wiki/Schema_migration)
+to handle updating Submitty's databases, both in development and production,
 in such a way that it is repeatable, easy to see the status of a given database,
 and that we are not left with partial DB upgrades due to a broken script.
 
-To do this, we utilize a custom migration tool written for Submitty, 
+To do this, we utilize a custom migration tool written for Submitty,
 [migrator](https://github.com/Submitty/Submitty/tree/master/migration). This tool
 can be used manually, as well as being baked into the
 installation/upgarde procedure of Submitty. For instance, running
-`/usr/local/submitty/.setup/INSTALL_SUBMITTY.sh` will apply any pending
+`bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh` will apply any pending
 migrations for all environments.
 
 The migrator tool has three distinct "environments" that all have their
@@ -112,7 +112,7 @@ directory or file structure:
     Or make changes to the complete database schema(s):
 
     `GIT_CHECKOUT/Submitty/migration/data/submitty_db.sql`
-    `GIT_CHECKOUT/Submitty/migration/data/course_tables.sql` 
+    `GIT_CHECKOUT/Submitty/migration/data/course_tables.sql`
 
 
 2.  And you should also prepare a migration file of the appropriate
@@ -148,11 +148,11 @@ directory or file structure:
     session, and then for course migration, the semester and course
     being affected. For interacting with the DB, you'll mainly just
     want to use:
-    
+
     ```
     database.execute("SQL QUERY TO RUN")
     ```
-    
+
     which will run the query automatically within a transaction that's
     started before running the migration file.
 
@@ -161,7 +161,7 @@ directory or file structure:
 
     NOTE: The `up` and `down` functions are optional to be defined and
     you can omit the function if you do not need it for your migration.
-  
+
     NOTE: In general, your `down` migration should only undo the
     necessary changes to make earlier versions of the Submitty
     software work.  For example, if your migration is adding a column
@@ -171,7 +171,6 @@ directory or file structure:
     in the future. Your `down` function may be empty.
 
     Thus, it is important to ensure that the `up` migration can be
-    re-run after the corresponding `down` migration is run.  For example, 
+    re-run after the corresponding `down` migration is run.  For example,
     your `up` function should not crash on adding the column if the column
     already exists.
-

--- a/_docs/developer/rainbow_grades_tests.md
+++ b/_docs/developer/rainbow_grades_tests.md
@@ -13,7 +13,7 @@ message) any test suite failures.
 
 Before running the test suite, you will need to ensure that autograding
 for csci1100 has been completed, and that you have generated grade
-reports for the course. This is the first step on the 
+reports for the course. This is the first step on the
 [Rainbow Grades](/instructor/rainbow_grades) page.
 
 Right now Travis does not run the csci1100 test since the autograding of
@@ -25,11 +25,11 @@ run the tests described on this page before making a pull request.
 
 To test that generated grade summaries match the expected summaries and
 that Rainbow Grades works correctly with the current course data, pass the
-optional "clean" and "test_rainbow" arguments to the `INSTALL_SUBMITTY.sh` 
+optional "clean" and "test_rainbow" arguments to the `install_submitty.sh`
 script:
 
-``` 
-sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh clean test_rainbow 
+```
+sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh clean test_rainbow
 ```
 
 ### Specific Rainbow Grades Tests

--- a/_docs/developer/updating_dependencies.md
+++ b/_docs/developer/updating_dependencies.md
@@ -93,7 +93,7 @@ meaningfully versioned beyond being committed into this repository.
 The version of [Submitty/pdf-annotate.js](https://github.com/Submitty/pdf-annotate.js) that
 is installed to the server is handled by `.setup/bin/version.sh` where the minified
 copy of the sourcecode is gotten via HTTP and installed to `site/public/js/pdf`. This gets
-updated/installed as part of running `INSTALL_SUBMITTY.sh` to update the rest of Submitty.
+updated/installed as part of running `install_submitty.sh` to update the rest of Submitty.
 
 #### PDF.js
 

--- a/_docs/developer/updating_dependencies.md
+++ b/_docs/developer/updating_dependencies.md
@@ -11,7 +11,7 @@ can be broken down largely into a couple of categories:
 4. Front-End Libraries
 
 ## Other Submitty Repositories
-While much of the code that makes up Submitty resides within the primary 
+While much of the code that makes up Submitty resides within the primary
 [Submitty/Submitty](https://github.com/Submitty/Submitty) repository, there are some components
 that reside outside of it. These include:
 1. [Submitty/AnalysisTools](https://github.com/Submitty/AnalysisTools)
@@ -19,11 +19,11 @@ that reside outside of it. These include:
 1. [Submitty/RainbowGrades](https://github.com/Submitty/RainbowGrades)
 1. [Submitty/Tutorial](https://github.com/Submitty/Tutorial)
 
-Each of these dependencies are installed/updated as part of the process of running INSTALL_SUBMITTY.sh,
+Each of these dependencies are installed/updated as part of the process of running install_submitty.sh,
 which in-turn calls `.setup/bin/update_repos.sh` to either clone or update the repo as necessary. The
 version that gets installed for each of these is defined in `.setup/bin/versions.sh`. Each of these
 are cloned into `${SUBMITTY_INSTALL_DIR}/GIT_CHECKOUT/`. Additionally, we do download the
-generated binaries for the appropriate version of Submitty/AnalysisTools into 
+generated binaries for the appropriate version of Submitty/AnalysisTools into
 `${SUBMITTY_INSTALL_DIR}/SubmittyAnalysisTools` to avoid the expensive process of getting the
 whole stack toolchain to compile it on the spot.
 
@@ -46,14 +46,14 @@ analysis and test runners for some languages. These are:
 The versions that we install of these is defined in `.setup/bin/versions.sh`. These are only
 installed at initial system installation as part of `.setup/install_system.sh`. For
 each of these, we download the compiled versions of the tool and then install into the
-appropriate directory (e.g. `${SUBMITTY_INSTALL_DIR}/java_tools` for Java stuff, 
+appropriate directory (e.g. `${SUBMITTY_INSTALL_DIR}/java_tools` for Java stuff,
 `${SUBMITTY_INSTALL_DIR}/drmemory`).
 
 ## Front-End Libraries
 Submitty relies on a number of front-end JS/CSS libraries to help make it look and
-feel the way it does. Each of these are checked-in and available in the 
+feel the way it does. Each of these are checked-in and available in the
 Submitty/Submitty repository. One of the overarching goals is that Submitty should
-not make any calls to outside servers for running the UI. 
+not make any calls to outside servers for running the UI.
 
 The dependencies that fall udner this cateogry include:
 1. jQuery

--- a/_docs/sysadmin/installation.md
+++ b/_docs/sysadmin/installation.md
@@ -33,7 +33,7 @@ _Note: These instructions should be run under root/sudo._
    ```
    bash -c "$(curl -s https://raw.githubusercontent.com/Submitty/Submitty/master/.setup/bootstrap.sh)"
    ```
-   
+
    or clone the git repository and run the installer (requires git and lsb-release to be installed):
 
    ```
@@ -63,7 +63,7 @@ _Note: These instructions should be run under root/sudo._
    you with the specified name & password.
 
 
-4. Run installations specific to your university.  
+4. Run installations specific to your university.
    For example:  [RPI Computer Science specific installations](https://github.com/Submitty/Submitty/blob/master/.setup/distro_setup/ubuntu/rpi.sh)
 
    ```
@@ -151,9 +151,7 @@ _Note: These instructions should be run under root/sudo._
    can better secure your DB if you don't plan to connect to it via localhost,
    IP, etc. The socket by default is run at `/var/run/postgresql`. To disable
    TCP, you will need to edit `/etc/postgresql/9.5/main/pg_hba.conf` and
-   disable all the lines that start with `host` and `hostssl`. You will also
-   have to modify `/usr/local/submitty/.setup/INSTALL_SUBMITTY.sh` and change
-   `DATABASE_HOST` to point to the socket, and then re-run the script.
+   disable all the lines that start with `host` and `hostssl`.
 
    NOTES:
    - When using Ubuntu 18.04, the configuration file path to disable TCP is

--- a/_docs/sysadmin/installation.md
+++ b/_docs/sysadmin/installation.md
@@ -151,7 +151,9 @@ _Note: These instructions should be run under root/sudo._
    can better secure your DB if you don't plan to connect to it via localhost,
    IP, etc. The socket by default is run at `/var/run/postgresql`. To disable
    TCP, you will need to edit `/etc/postgresql/9.5/main/pg_hba.conf` and
-   disable all the lines that start with `host` and `hostssl`.
+   disable all the lines that start with `host` and `hostssl`. You will need
+   to re-run `CONFIGURE_SUBMITTY.py` to update the database host to point to
+   the socket, and re-run `install_submitty.sh`.
 
    NOTES:
    - When using Ubuntu 18.04, the configuration file path to disable TCP is

--- a/_docs/sysadmin/update.md
+++ b/_docs/sysadmin/update.md
@@ -27,14 +27,14 @@ Please also see [Installation Version Notes](version_notes)
 2.  Then re-install the Submitty source code.
 
     ```
-    sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh
+    sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh
     ```
 
     If you provide the optional `restart_web` option, the script will
     also restart Apache and PHP-FPM:
 
     ```
-    sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh restart_web
+    sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh restart_web
     ```
 
     One of the early steps of this script checks your system
@@ -64,8 +64,8 @@ Please also see [Installation Version Notes](version_notes)
 
 1.  First let's move your Submitty source code repository to its new suggested location:
 
-    **Old repository path suggestion:**   `/usr/local/submitty/GIT_CHECKOUT_Submitty`  
-    **New repository path suggestion:**   `/usr/local/submitty/GIT_CHECKOUT/Submitty`     
+    **Old repository path suggestion:**   `/usr/local/submitty/GIT_CHECKOUT_Submitty`
+    **New repository path suggestion:**   `/usr/local/submitty/GIT_CHECKOUT/Submitty`
 
     If you have _not_ modified any of the helper Submitty repositories
     (`GIT_CHECKOUT_Tutorial`, `GIT_CHECKOUT_AnalysisTools`, etc.) stored

--- a/_docs/sysadmin/version_notes/v.19.06.01.md
+++ b/_docs/sysadmin/version_notes/v.19.06.01.md
@@ -58,16 +58,16 @@ Edit your Apache configuration:
 
         RewriteEngine On
 
-        # If the requested filename exists, simply serve it.                                             
+        # If the requested filename exists, simply serve it.
         RewriteCond %{REQUEST_FILENAME} -f
         RewriteRule ^ - [L]
 
-        # Else rewrite urls to use index.php, however we have to be aware of two                         
-        # possible conditions of whether index.php is in the URL already or not.                         
-        # To be backwards compatible, we want to ensure that having /index.php                           
-        # is valid and usable. In anycase, we rewrite everything up-to /index.php                        
-        # to be the "url" parameter of the query, and then append whatever else we                       
-        # had in the QUERY_STRING after it.                                                              
+        # Else rewrite urls to use index.php, however we have to be aware of two
+        # possible conditions of whether index.php is in the URL already or not.
+        # To be backwards compatible, we want to ensure that having /index.php
+        # is valid and usable. In anycase, we rewrite everything up-to /index.php
+        # to be the "url" parameter of the query, and then append whatever else we
+        # had in the QUERY_STRING after it.
         RewriteRule ^(.+)/index\.php$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
         RewriteRule ^(.+)$ /index.php?url=$1&%{QUERY_STRING} [NC,END]
 
@@ -90,7 +90,7 @@ Edit your Apache configuration:
     machine to v.19.06.01 or later
 
     ```
-    sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh
+    sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh
     ```
 
 
@@ -115,7 +115,7 @@ the repository (with edits) and restart Apache.
 1. Copy the Apache config from the repostiory:
 
    ```
-   cp /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/vagrant/sites-available/submitty.conf /etc/apache2/sites-enabled/submitty.conf 
+   cp /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/vagrant/sites-available/submitty.conf /etc/apache2/sites-enabled/submitty.conf
    ```
 
 
@@ -127,4 +127,3 @@ the repository (with edits) and restart Apache.
    ```
    sudo systemctl restart apache2.service
    ```
-

--- a/_docs/sysadmin/version_notes/v19.08.03.md
+++ b/_docs/sysadmin/version_notes/v19.08.03.md
@@ -32,7 +32,7 @@ Edit your Apache configuration:
    * Move `index.html` to the front of the list:
 
        old code:
-       ``` 
+       ```
        DirectoryIndex index.php index.cgi index.html
        ```
 
@@ -74,12 +74,12 @@ Edit your Apache configuration:
     machine to v19.08.03 or later, e.g.:
 
     ```
-    sudo /usr/local/submitty/.setup/INSTALL_SUBMITTY.sh
+    sudo bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh
     ```
 
     During the 1-2 minutes of installation if you load any page on the
     website you will see a simple maintenance page with this message:
-    
+
 
 
     ![](/images/installation_update.png)

--- a/_docs/sysadmin/worker_installation.md
+++ b/_docs/sysadmin/worker_installation.md
@@ -39,7 +39,7 @@ The user should only be used for submitty related activities.
    You will be asked to provide the name of your submitty user by the
    [CONFIGURE_SUBMITTY.sh script](https://github.com/Submitty/Submitty/blob/master/.setup/CONFIGURE_SUBMITTY.sh).
 
-5. Run installations specific to your university.  
+5. Run installations specific to your university.
    For example:  [RPI Computer Science specific installations](https://github.com/Submitty/Submitty/blob/master/.setup/distro_setup/ubuntu/rpi.sh)
 
    ```
@@ -57,8 +57,8 @@ The user should only be used for submitty related activities.
 7. Next, we must set up an ssh key so that submitty_daemon user on the primary
   machine can copy files to our worker machine.
 
-  On primary submitty:  
-  ___NOTE: ssh-keygen asks for the name of your submitty user.___  
+  On primary submitty:
+  ___NOTE: ssh-keygen asks for the name of your submitty user.___
   ___NOTE: The ssh-copy-id line requires a replacement___
   ```
   su submitty_daemon
@@ -68,7 +68,7 @@ The user should only be used for submitty related activities.
   ```
 
 8. Finally, we must add the machine to the list of workers available to our
-  primary machine. To do this:  
+  primary machine. To do this:
   *  Log on to the primary Submitty machine.
   *  Open ```/usr/local/submitty/config/autograding_workers.json``` with your favorite text editor.
   *  Add a new entry with a unique key.
@@ -79,9 +79,9 @@ The user should only be used for submitty related activities.
   *  Add the name of the submitty user on the machine as the username.
   *  Set the machine to be enabled.
 
-9. Run ```/usr/local/submitty/.setup/INSTALL_SUBMITTY.sh``` so that the changes take effect.
+9. Run ```bash /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/install_submitty.sh``` so that the changes take effect.
 
-10. Inside of your assignment configurations, you may now add the line  
+10. Inside of your assignment configurations, you may now add the line
   ```
     required_capabilities : 'CAPABILITY'
   ```


### PR DESCRIPTION
Docs update for Submitty/Submitty#4600

Does not look like we actually have anywhere in the docs explicitly for running the `install_submitty.sh` script.