### PR TITLE
[Documentation:Migrations] Changed typo from migrator.py to run_migrator.py

### DIFF
--- a/_docs/developer/migrations.md
+++ b/_docs/developer/migrations.md
@@ -62,7 +62,7 @@ database (for course migrations).
 To see additional options, run:
 
 ```
-sudo python3 /usr/local/submitty/GIT_CHECKOUT/Submitty/migration/migrator.py -h
+sudo python3 /usr/local/submitty/GIT_CHECKOUT/Submitty/migration/run_migrator.py -h
 ```
 
 


### PR DESCRIPTION
When looking over the migration docs I tried to run the line `sudo python3 /usr/local/submitty/GIT_CHECKOUT/Submitty/migration/migrator.py -h` however that file was not found. I could be wrong (I am new to this which is why I was reading the docs) but I think it should have been run_migrator.py not migrator.py. The command above on the page does use run_migrator.py and it works.