### PR TITLE
[Documentation:JSON Configuration Files] added missing /courses to path

### DIFF
--- a/_docs/developer/json_configuration_files.md
+++ b/_docs/developer/json_configuration_files.md
@@ -8,7 +8,7 @@ The system configuration and state are stored in several different
 types of JSON data files.  demonstration purposes we assume the system
 has a user "smithj" and assignment "hw1".  The examples below are
 relative to a top level course path
-```/var/local/submitty/f16/csci1100/```, for assignment ```hw1``` and
+```/var/local/submitty/courses/f16/csci1100/```, for assignment ```hw1``` and
 student ```smithj```. Listed are first the JSON files and then
 examples of these JSON files.
 


### PR DESCRIPTION
The path to get to the course data seems to be missing `/courses` in it

On my local version of submitty the path is `/var/local/submitty/courses/f19/` however the docs have it as `/var/local/submitty/f19/`

