### PR TITLE
add note about running composer install to install/setup phpcs

### DIFF
--- a/_docs/developer/coding_style_guide/php.md
+++ b/_docs/developer/coding_style_guide/php.md
@@ -14,22 +14,21 @@ code structure and naming conventions. These customizations are shown below.
 
 We use a custom standard for the [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) tool,
 available at [Submitty/submitty-php-codesniffer](https://github.com/Submitty/submitty-php-codesniffer).
-You can lint your code, assuming that you are in `site/` by doing:
+To set up the tool to use it, all you need to do is run `composer install` from within the `site/` directory,
+which handles installing the dependencies and setting up the
+[phpcs install paths](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths).
+To run `phpcs`, you can use the following command:
 
-```
+```bash
 vendor/bin/phpcs --standard=tests/ruleset.xml [path/to/file/or/directory]
 ```
 
 where if you leave off the path, it will analyze all files and directories for Submitty.
-
 Additionally, you can apply the automatic fixer to your code by running:
 
-```
+```bash
 vendor/bin/phpcbf --standard=tests/ruleset.xml [path/to/file/or/directory]
 ```
-
-where this can fix a large range of possible PHPCS style errors, though some may require
-manual intervention.
 
 ### Classes, Methods
 
@@ -38,7 +37,7 @@ manual intervention.
 * The opening brace for a method MUST have one space between it and the closing parenthesis.
 * The closing brace for a method MUST go on the next line following the body.
 
-```
+```php
 class Test {
     public function foo() {
         // code
@@ -64,7 +63,7 @@ class Test {
 * The closing brace MUST be on the next line after the body
 * There MUST be one newline between closing brace and the next control structure keyword except for do-while
 
-```
+```php
 if ($foo) {
     // code
 }
@@ -76,12 +75,11 @@ else {
 }
 ```
 
-```
+```php
 do {
     // code
 } while ($foo);
 ```
-
 
 ### Naming Conventions
 


### PR DESCRIPTION
There was some internal discussion at RPI about how to get this line working. Adds a note above about using `composer install` to just do this, though points at the relevant wiki page at phpcs if someone wants to learn how to do it manually.