### PR TITLE
Fix type of config field email_enabled in docs

### DIFF
--- a/_docs/developer/development_instructions/vagrant_email_configuration.md
+++ b/_docs/developer/development_instructions/vagrant_email_configuration.md
@@ -17,6 +17,7 @@ On the developer vagrant machine, the sending of emails is simulated with the
 
    ```
    {
+       "email_enabled": true,
        "email_sender": "submitty@myuniversity.edu",
        "email_reply_to": "submitty_do_not_reply@myuniversity.edu",
        "email_server_hostname": "localhost",

--- a/_docs/sysadmin/email_configuration.md
+++ b/_docs/sysadmin/email_configuration.md
@@ -34,7 +34,7 @@ First, the Submitty server must be configured to send email:
 
     ```
     {
-      "email_enabled": "true"
+      "email_enabled": true,
       "email_user": "<SPECIAL USER NAME>",
       "email_password": "<PASSWORD FOR SPECIAL USER NAME>",
       "email_sender": "submitty@myuniversity.edu",


### PR DESCRIPTION
The json files had "true" as a string when it should have been true. Also one file was missing true to begin with.