### PR TITLE
[Bugfix:url] Fixed broken url for e2e tests

### DIFF
--- a/_docs/developer/php_unit_tests.md
+++ b/_docs/developer/php_unit_tests.md
@@ -8,7 +8,7 @@ These are general details and instructions for testing the PHP code
 with PHPUnit. OS specific instructions are below.
 
 The primary method of testing for the PHP code is _Unit Testing_, along
-with [End to End Tests](end_to_end_tests.md)
+with [End to End Tests](end_to_end_tests)
 
 These tests require that you have
 [PHPUnit](https://phpunit.de/) on your system. PHP 7.2 or PHP 7.3 is 


### PR DESCRIPTION
The page for e2e test should not have .md on it.

[https://submitty.org/developer/end_to_end_tests.md](https://submitty.org/developer/end_to_end_tests.md) fails

[https://submitty.org/developer/end_to_end_tests](https://submitty.org/developer/end_to_end_tests) works