### PR TITLE
[Documentation:Developer] Added instructions on how to start nullsmtpd

### DIFF
--- a/_docs/developer/development_instructions/vagrant_email_configuration.md
+++ b/_docs/developer/development_instructions/vagrant_email_configuration.md
@@ -31,10 +31,9 @@ On the developer vagrant machine, the sending of emails is simulated with the
    ```bash
    systemctl status nullsmtpd
    ```
-   If it is not running, you can run the following 2 commands to enable it:
+   If it is not running, run the following command to start it:
    ```bash
    systemctl start nullsmtpd
-   systemctl enable nullsmtpd
    ```
 
 

--- a/_docs/developer/development_instructions/vagrant_email_configuration.md
+++ b/_docs/developer/development_instructions/vagrant_email_configuration.md
@@ -15,7 +15,7 @@ On the developer vagrant machine, the sending of emails is simulated with the
 
 1. The email configuration file, `/usr/local/submitty/config/email.json`, should contain:
 
-   ```
+   ```json
    {
        "email_enabled": true,
        "email_sender": "submitty@myuniversity.edu",
@@ -28,8 +28,13 @@ On the developer vagrant machine, the sending of emails is simulated with the
 
 2. Verify that the `nullsmtpd` daemon is running:
 
-   ```
+   ```bash
    systemctl status nullsmtpd
+   ```
+   If it is not running, you can run the following 2 commands to enable it:
+   ```bash
+   systemctl start nullsmtpd
+   systemctl enable nullsmtpd
    ```
 
 


### PR DESCRIPTION
This adds instructions for how to start and enable nullsmtpd for people that dont use linux very often and might now know how systemctl works.