### PR TITLE
[Documentation:Developer] Added a reminder to fork the repo for new devs

### DIFF
--- a/_docs/developer/vm_install_using_vagrant.md
+++ b/_docs/developer/vm_install_using_vagrant.md
@@ -83,7 +83,7 @@ operating system.
    
    **NOTE:** If you are not currently part of the Submitty organization on Github, you may want to
    [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)
-   the repo and use the git url from your fork instead.
+   the repo and use the git url from your fork instead, especially if you are looking to contribute.
 
    _OPTIONAL: If you will be developing code in one of the companion
    Submitty repositories (e.g., AnalysisTools, Lichen, RainbowGrades, Tutorial), also

--- a/_docs/developer/vm_install_using_vagrant.md
+++ b/_docs/developer/vm_install_using_vagrant.md
@@ -80,6 +80,10 @@ operating system.
    ```
    git clone https://github.com/Submitty/Submitty.git
    ```
+   
+   **NOTE:** If you are not currently part of the Submitty organization on Github, you may want to
+   [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)
+   the repo and use the git url from your fork instead.
 
    _OPTIONAL: If you will be developing code in one of the companion
    Submitty repositories (e.g., AnalysisTools, Lichen, RainbowGrades, Tutorial), also


### PR DESCRIPTION
This adds a reminder for new developers that they may want to fork the repo. I know this is common sense for a lot of us but for new developers, especially from gsoc, who we do not want to add to the Submitty github organization this will help remind them to use a fork. 

Somebody had this issue on slack and while it is not too hard to solve, I think having this reminder  could reduce the likelihood for this kind of problem going forward.