### PR TITLE
Updated markdown documentation

### DIFF
--- a/_docs/student/discussion_forum.md
+++ b/_docs/student/discussion_forum.md
@@ -81,9 +81,14 @@ communication between students and the teaching staff.
 Markdown has become a common standard for formatting online text.
 Click on the markdown symbol to enable formatting of your post using markdown.
 
-The most useful features of markdown for the Submitty Discussion Forum
-are the code blocks (fixed width font) and external url links.  We provide
-quick link buttons to insert the markdown formatting characters for
-these features into your post.
+   **_Links_** "\[display text\]\(url\)" will add a hyperlink to a URL with "display text" displayed.
 
-The discussion forum does not support image markdown (`![alt](linkToImage)`). Markdown syntax for images will be converted to a hyperlink. 
+   **_Code_** Adding ```` ``` ```` above and below text will turn it into a code block.
+
+   **_Bold_** Adding \_\_ before and after text (two underscores) will make that text bold.
+
+   **_Italics_** Adding \_ before and after text (one underscore) will italicize that text.
+
+   **_Bullets_** Adding \* (unordered list) or numbers (ex. 1., 2.) (ordered list) before text and with a space will put text into a bulleted list.
+
+We provide quick link buttons to insert some markdown formatting characters for these features into your post.

--- a/_docs/student/discussion_forum.md
+++ b/_docs/student/discussion_forum.md
@@ -89,6 +89,16 @@ Click on the markdown symbol to enable formatting of your post using markdown.
 
    **_Italics_** Adding \_ before and after text (one underscore) will italicize that text.
 
-   **_Bullets_** Adding \* (unordered list) or numbers (ex. 1., 2.) (ordered list) before text and with a space will put text into a bulleted list.
+   **_Bullets_** Adding \* or numbers (ex. 3., 1., 3.) before text and with a space will put text into a bulleted list (with \* or the number as the bullet point).
+
+   For example:
+   ``` 
+   * Item 1
+   * Item 2
+   
+   3. Item 1
+   1. Item 2
+   3. Item 3
+   ```
 
 We provide quick link buttons to insert some markdown formatting characters for these features into your post.


### PR DESCRIPTION
Updated the markdown documentation to add bullets, reformatted it a bit.
Images can be added using (very weird) syntax, but I didn't add it into the documentation since attachments should probably be used instead (when adding images in, I didn't see a way to change the size of the image when displayed)