### PR TITLE
[Documentation] Rewrite section on third-party dependencies

### DIFF
--- a/_docs/developer/updating_dependencies.md
+++ b/_docs/developer/updating_dependencies.md
@@ -5,15 +5,18 @@ category: Developer
 
 Within Submitty, we have a number of third-party dependencies to help augment the system. These
 can be broken down largely into a couple of categories:
+
 1. Other Submitty Repositories
 2. Third-Party Repositories
 3. Third-Party Distributions
-4. Front-End Libraries
+4. Third-Party Dependencies
 
 ## Other Submitty Repositories
+
 While much of the code that makes up Submitty resides within the primary 
 [Submitty/Submitty](https://github.com/Submitty/Submitty) repository, there are some components
 that reside outside of it. These include:
+
 1. [Submitty/AnalysisTools](https://github.com/Submitty/AnalysisTools)
 1. [Submitty/Lichen](https://github.com/Submitty/Lichen)
 1. [Submitty/RainbowGrades](https://github.com/Submitty/RainbowGrades)
@@ -28,20 +31,24 @@ generated binaries for the appropriate version of Submitty/AnalysisTools into
 whole stack toolchain to compile it on the spot.
 
 ## Third-Party Repositories
+
 While the `GIT_CHECKOUT` folder mostly holds Submitty related repos, it does also contain these
 third-party repos:
+
 1. [nlohmann/json](https://github.com/nlohmann/json)
 
 These repos are cloned under `${SUBMITTY_INSTALL_DIR}/GIT_CHECKOUT/vendor/`. Currently they are
 not versioned.
 
 ## Third-Party Distributions
+
 For autograding, Submitty relies on a handful of third-party tools to handle stuff like memory
 analysis and test runners for some languages. These are:
+
 1. [DrMemory](https://drmemory.org/)
 1. [Junit 4](https://junit.org/junit4/)
 1. [Emma](https://github.com/Submitty/emma)
-1. [Jacoco](https://www.eclemma.org/jacoco/)
+1. [JaCoCo](https://www.eclemma.org/jacoco/)
 
 The versions that we install of these is defined in `.setup/bin/versions.sh`. These are only
 installed at initial system installation as part of `.setup/install_system.sh`. For
@@ -49,60 +56,18 @@ each of these, we download the compiled versions of the tool and then install in
 appropriate directory (e.g. `${SUBMITTY_INSTALL_DIR}/java_tools` for Java stuff, 
 `${SUBMITTY_INSTALL_DIR}/drmemory`).
 
-## Front-End Libraries
-Submitty relies on a number of front-end JS/CSS libraries to help make it look and
-feel the way it does. Each of these are checked-in and available in the 
-Submitty/Submitty repository. One of the overarching goals is that Submitty should
-not make any calls to outside servers for running the UI. 
+## Third-Party Dependencies
 
-The dependencies that fall udner this cateogry include:
-1. jQuery
-1. jQuery.are-you-sure
-1. jQuery-UI
-1. jQuery-UI-Timepicker-Addon
-1. fontawesome
-1. google fonts
-1. PDF.js
-1. Submitty/pdf-annotate.js
-1. flatpickr
-1. Twig.js
-1. CodeMirror
+To manage PHP dependencies, we use [composer](https://getcomposer.org/), and the packages it installs
+can be found in [site/composer.json](https://github.com/Submitty/Submitty/blob/master/site/composer.json).
 
-How these are managed/installed can be broken down as follows:
+To manage JS/CSS dependencies, we use [npm](https://npmjs.com), and the packages it installs can be found
+in [site/package.json](https://github.com/Submitty/Submitty/blob/master/site/package.json).
 
-#### CodeMirror
-This one is installed to `site/public/js/iframe`. Installation of new versions of CodeMirror
-is handled by running `.setup/bin/update_codemirror.sh` which will grab the latest version
-of CodeMirror from their website and copy the appropriate minified files into the right
-place in the Submitty hierarchy, as well as write the version that is installed to the top
-of the main CodeMirror JS file.
+As Submitty is an application, not a library, each dependency in both of those files are pinned to a specific
+version, and should not be set to use a range (e.g. use `1.0.0` over `^1.0.0`).
 
-#### FontAwesome
-FontAwesome is installed to `site/public/vendor/fontawesome`. Updating these files is handled
-by running `.setup/bin/update_fontawesome.sh`. You will have to change the `VERSION` variable
-in that file to adjust what version of FontAwesome to install.
-
-#### Google Fonts
-Google Fonts is installed to `site/public/vendor/google`. Updating these files is handled
-by running `.setup/bin/update_googlefonts.sh`. You should not need to often run this file
-as the fonts themselves are relatively stable and don't change that much, and they are
-meaningfully versioned beyond being committed into this repository.
-
-#### Submitty/pdf-annotate.js
-
-The version of [Submitty/pdf-annotate.js](https://github.com/Submitty/pdf-annotate.js) that
-is installed to the server is handled by `.setup/bin/version.sh` where the minified
-copy of the sourcecode is gotten via HTTP and installed to `site/public/js/pdf`. This gets
-updated/installed as part of running `INSTALL_SUBMITTY.sh` to update the rest of Submitty.
-
-#### PDF.js
-
-This is a dependency of using Submitty/pdf-annotate.js, and it is currently manually
-handled for updating. The JS files reside under `site/public/js/pdf` while the CSS files
-reside under `site/public/css/pdf`.
-
-#### Everything Else
-
-All other files are manually handled in updating and managing them. All of their JS files
-reside under `site/public/js` while their CSS files reside under `site/public/css`. You will
-have to open the file to look at the header to determine what version is installed.
+For python dependencies, we use [pip](https://pip.pypa.io/en/stable/). These are installed currently only at
+installation time, and not managed by Submitty currently. The current list of packages can be found in
+[.setup/install_system](https://github.com/Submitty/Submitty/blob/master/.setup/install_system.sh). You should
+search for "pip3 install" to find all things that pip installs.


### PR DESCRIPTION
Rewrites the section to be reflective of what's going on as we've moved away from using scripts to maintain all of those dependencies, and now use composer / npm for it all.