### PR TITLE
iClicker Documentation Updates

### DIFF
--- a/_docs/instructor/rainbow_grades/iclicker_instructions.md
+++ b/_docs/instructor/rainbow_grades/iclicker_instructions.md
@@ -20,9 +20,9 @@ you can scrape the iclicker with this command:
 
 Note: Students often misunderstand which digits on the back of their
 remote are their unique remote ID.  Many type in the model number of
-the clicker that begins with "T24" or something.  The remote ID is the
+the clicker that begins with something like "T24".  The remote ID is the
 8 digit number/letter string that is on the white sticker next to the
-battery.
+battery, and will only contain numbers and the letters A-F.
 
 
 ## Remote ID file
@@ -37,9 +37,10 @@ iClicker IDs to student IDs, an example row might read:
 The leading ``#``, the letters in the iClicker ID being capitalized, and
 the student ID being wrapped in quotation marks are all important.
 
-NOTE: iClicker support is based on iClicker software version 6, and may not
-work with newer versions.
-
+NOTE: iClicker support is based on the "iClicker Classic" software (formerly known 
+as versions 6 (.csv files) and 7 (.xml files)), and may not work with newer versions.
+When running Rainbow Grades, a matching .csv file will be automatically created
+for any .xml file in your `customization.json` file.
 
 
 ## Remote ID file
@@ -53,6 +54,20 @@ make iClickers work.
 
   The string is a relative path (it can just be a name if it is in the
   `grades_summary` directory).
+
+* **field:** ``"earned_late_days"``  
+  **type:** _array of numbers_  
+  **OPTIONAL**
+
+  If this array is filled in, then Rainbow Grades will generate a `late_days.txt` 
+  that can be uploaded to Submitty via the ``"Late Days Allowed"`` page. The 
+  numbers in the array should be increasing and indicate the number of iclicker 
+  points required to award students an extra late day. The file also contains the 
+  effective date that the late day was earned, which is calculated based on the 
+  timestamps embedded in the iClicker filenames.
+
+  NOTE: You must manually upload the `late_days.txt` file via the Submitty web 
+  interface. It is *NOT* uploaded by running `make push`.
 
 * **field:** ``"iclicker"``  
   **type:** _associative array of string to array_  
@@ -73,7 +88,7 @@ make iClickers work.
     MM is the 2-digit month 01-12, DD is the 2-digit day 01-31, HH is the two digit hour 00-23, 
     and II is the 2-digit minute 00-59). Multiple files can be used for one lecture. Currently,
     multiple files can be used for one question even, but the column number and correct answer(s)
-    must match in the files.
+    must match for all files in a given ``"file"`` array.
 
   * **field:** ``"column"``  
     **type:** _integer_  
@@ -92,22 +107,26 @@ make iClickers work.
     yellow. For any other question, student responses will be highlighted in green if they are correct
     (1.0 points towards iClicker score) and red if they are incorrect (0.5 points towards iClicker score).
 
-
 Below is a short example which gets questions 2.1 (a poll) and 2.2 (two right answers) from one file,
-and 2.3 from another file which also contains 3.1 (a poll).
+and 2.3 from another pair of files which also contain 3.1 (a poll). 
+
+The example also allows students to earn an additional late day after getting 2 iClicker points, 
+and a second late day after 6 iClicker points (not yet attainable in the example, which only has a 
+total of 4 questions).
 
 
 ```     
 "iclicker_ids": "clicker_data/RemoteID.csv",
 "iclicker": {
   "2": [
-    {"file": "clicker_data/L1701201013.csv", "column": 1, "answer": "ABCDE"},
-    {"file": "clicker_data/L1701201013.csv", "column": 2, "answer": "AE"},
-    {"file": "clicker_data/L1701220958.csv", "column": 1, "answer": "D"},
+    {"file": ["clicker_data/L1701201013.csv"], "column": 1, "answer": "ABCDE"},
+    {"file": ["clicker_data/L1701201013.csv"], "column": 2, "answer": "AE"},
+    {"file": ["clicker_data/L1701220958.csv", "clicker_data/L1701221358.xml"], "column": 1, "answer": "D"},
   ],     
   "3": [
-    {"file": "clicker_data/L1701220958.csv", "column": 2, "answer": "ABCDE"},           
+    {"file": ["clicker_data/L1701220958.csv", "clicker_data/L1701221358.xml"], "column": 2, "answer": "ABCDE"},           
   ]
-}
+},
+"earned_late_days": [2.0, 6.0]
 ```
 


### PR DESCRIPTION
Closes Submitty/Submitty#1580

Made some significant changes to the wording about supported versions, a few other minor tweaks, and added the `earned_late_days` field in.

Also importantly Updated iClicker documentation to be consistent with 2018 onwards which has expected `file` to be an array (yes, we still called it `file` instead of `files` in Rainbow Grades). I got some nasty looking errors when I tried without making it an array (due to how the Python script that looks to see if there's XML files that need scooping up works).