### PR TITLE
[Documentation] use pg_dump for migrator sql

### DIFF
--- a/_docs/developer/migrations.md
+++ b/_docs/developer/migrations.md
@@ -175,3 +175,11 @@ directory or file structure:
     your `up` function should not crash on adding the column if the column
     already exists.
 
+3.  After you have written your migration and are satisfied that it works,
+    you will have to then modify the base .sql files Submitty uses on. To
+    accomplish this, run the following two commands from within Vagrant:
+    
+    ```bash
+    su - postgres -c "pg_dump -d submitty --schema-only --no-privileges --no-owner --file /usr/local/submitty/GIT_CHECKOUT/Submitty/migration/migrator/data/submitty_db.sql"
+    su - postgres -c "pg_dump -d submitty_s20_sample --schema-only --no-privileges --no-owner --file /usr/local/submitty/GIT_CHECKOUT/Submitty/migration/migrator/data/course_tables.sql"
+    ```

--- a/_docs/developer/migrations.md
+++ b/_docs/developer/migrations.md
@@ -175,8 +175,10 @@ directory or file structure:
     your `up` function should not crash on adding the column if the column
     already exists.
 
-3.  After you have written your migration and are satisfied that it works,
-    you will have to then modify the base .sql files Submitty uses on. To
+3.  After you have written your migration to update an existing system 
+    and are satisfied that it works,
+    you must also update the base .sql files used to create a new 
+    Submitty system.  To
     accomplish this, run the following two commands from within Vagrant:
     
     ```bash


### PR DESCRIPTION
sister PR to Submitty/Submitty#5392

Adds two commands to the migrator docs to run to get the updated sql file from a result of using `pg_dump`. This simplifies the process of things for a developer of updating these files, and will make sure that this file is always uniformly designed.