### PR TITLE
Update php-sqlite to php-sqlite3 for Ubuntu setup

### DIFF
--- a/_docs/developer/testing/index.md
+++ b/_docs/developer/testing/index.md
@@ -61,7 +61,7 @@ pecl install xdebug
 For Ubuntu:
 
 ```bash
-sudo apt-get install php-cli php-mbstring php-xml php-xdebug php-curl php-zip php-sqlite composer
+sudo apt-get install php-cli php-mbstring php-xml php-xdebug php-curl php-zip php-sqlite3 composer
 sudo apt-get install python3 python3-pip
 ```
 


### PR DESCRIPTION
The current mentioned php-sqlite install causes the code to break in initial setup and does not process with composer install. The reason for this might be php sqlite is obsolete and is replaced by php-sqlite3