### PR TITLE
Replace search input title with meaningful aria-label

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,7 +47,7 @@
                 <!--{{ site.title }}-->
             </h1>
             <form action="{{ site.baseurl }}/search/" method="get">
-                <input type="text" name="q" id="search-input" placeholder="Search" title="q">
+                <input type="text" name="q" id="search-input" placeholder="Search" aria-label="Search content on submitty.org">
                 <input type="submit" value="Search" style="display: none;">
             </form>
             <ul>


### PR DESCRIPTION
Adds a meaningful aria-label attribute to the search input to assist screen readers to know what the input is for. I've removed the title attribute as I do not think it's valuable and if functionality is confusing would say just update the placeholder to be "Search submitty.org" or something.

Closes Submitty/Submitty#5552
