### PR TITLE
Add "curly" rule to javascript style guide

### DIFF
--- a/_docs/developer/coding_style_guide/javascript.md
+++ b/_docs/developer/coding_style_guide/javascript.md
@@ -115,3 +115,4 @@ directive. This includes functions and classes as well as regular variables.
 - [semi](https://eslint.org/docs/rules/semi) (always have semi-colons)
 - [semi-style](https://eslint.org/docs/rules/semi-style) (semi-colons are at end of lines)
 - [template-curly-spacing](https://eslint.org/docs/rules/template-curly-spacing) (enforces no spaces between curly braces and variable in template literals)
+- [curly](https://eslint.org/docs/rules/curly) (enforces curly braces for "if", "if-else", "while", and "for" blocks)

--- a/_docs/developer/coding_style_guide/javascript.md
+++ b/_docs/developer/coding_style_guide/javascript.md
@@ -42,6 +42,7 @@ directive. This includes functions and classes as well as regular variables.
 
 - [arrow-spacing](https://eslint.org/docs/rules/arrow-spacing)
 - [block-spacing](https://eslint.org/docs/rules/block-spacing)
+- [curly](https://eslint.org/docs/rules/curly) (enforces curly braces for "if", "if-else", "while", and "for" blocks)
 - [for-direction](https://eslint.org/docs/rules/for-direction)
 - [getter-return](https://eslint.org/docs/rules/getter-return)
 - [no-async-promise-executor](https://eslint.org/docs/rules/no-async-promise-executor)
@@ -115,4 +116,3 @@ directive. This includes functions and classes as well as regular variables.
 - [semi](https://eslint.org/docs/rules/semi) (always have semi-colons)
 - [semi-style](https://eslint.org/docs/rules/semi-style) (semi-colons are at end of lines)
 - [template-curly-spacing](https://eslint.org/docs/rules/template-curly-spacing) (enforces no spaces between curly braces and variable in template literals)
-- [curly](https://eslint.org/docs/rules/curly) (enforces curly braces for "if", "if-else", "while", and "for" blocks)


### PR DESCRIPTION
Adds the rule to existing rules used for JS linting along with a description and its link