### PR TITLE
Add documentation on installing PHP Locally 

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -217,6 +217,8 @@
         - name: CSS
     - name: Testing
       children:
+        - name: Installing PHP
+          link: install_php
         - name: Linting / Static Analysis
           link: linting_static_analysis
         - name: Python Unit Tests

--- a/_docs/developer/testing/install_php.md
+++ b/_docs/developer/testing/install_php.md
@@ -1,0 +1,31 @@
+---
+title: Install PHP
+---
+
+In order to run the PHP Linter, Static Analysis, and PHPUnit tests locally 
+you will need to have PHP installed on your host machine first.
+
+### Linux & WSL:
+
+*If you're distro cannot find the correct package or installs the wrong version you may have to specify php7.0 in each package name*
+
+```bash
+sudo apt-get update
+sudo apt-get install -y php php-curl php-xml php-mbstring 
+```
+### MacOS
+
+```bash
+brew install php
+```
+If you are missing extensions you can install them with `PECL` which will be 
+installed automatically with PHP, but you should have everything required by 
+default.
+
+------------- 
+
+Verify you have PHP installed correctly, submitty requires a version greater than 7.0
+
+```bash
+php -v
+```

--- a/_docs/developer/testing/linting_static_analysis.md
+++ b/_docs/developer/testing/linting_static_analysis.md
@@ -37,6 +37,8 @@ See also: [Python Style Guide](/developer/coding_style_guide/python)
 
 ## PHP Linting
 
+*You will need PHP installed on your host system first, see [Installing PHP](/developer/testing/install_php)*
+
 The PHP code of Submitty is linted using [phpcs](https://github.com/squizlabs/PHP_CodeSniffer).
 
 You can run the PHP Linter locally (from your host operating system):

--- a/_docs/developer/testing/linting_static_analysis.md
+++ b/_docs/developer/testing/linting_static_analysis.md
@@ -42,6 +42,7 @@ See also: [Python Style Guide](/developer/coding_style_guide/python)
 The PHP code of Submitty is linted using [phpcs](https://github.com/squizlabs/PHP_CodeSniffer).
 
 You can run the PHP Linter locally (from your host operating system):
+If you are running on WSL and are seeing errors, remove "`php`" from the following commands.
 
 ```bash
 # from root level of Submitty repository

--- a/_docs/developer/testing/php_unit_tests.md
+++ b/_docs/developer/testing/php_unit_tests.md
@@ -8,6 +8,8 @@ To validate the unit behavior of the site code, we utilize
 
 ### Running PHP Unit Tests
 
+*You will need PHP installed on your host system first, see [Installing PHP](/developer/testing/install_php)*
+
 To run the PHP unit test suite locally, `cd` to the `Submitty/site` directory and type:
 
 ```

--- a/_docs/developer/testing/php_unit_tests.md
+++ b/_docs/developer/testing/php_unit_tests.md
@@ -12,6 +12,8 @@ To validate the unit behavior of the site code, we utilize
 
 To run the PHP unit test suite locally, `cd` to the `Submitty/site` directory and type:
 
+If you are running on WSL and are seeing errors, remove "`php`" from the following commands.
+
 ```
 php vendor/bin/phpunit --configuration tests/phpunit.xml
 ```


### PR DESCRIPTION
Developer ran into trouble running php linter locally, did not have PHP installed on their system, adds documentation for it
Adds note for running on WSL which does not need the `php` command in front of the command for running php tools whereas linux and mac do.