### PR TITLE
[Documentation:Developer] Add Hyper-V warning

### DIFF
--- a/_docs/developer/vm_install_using_vagrant.md
+++ b/_docs/developer/vm_install_using_vagrant.md
@@ -41,7 +41,9 @@ instructions.
    Leaving it enabled will force VirtualBox to use the Hyper-V
    backend, which will be slower and can cause instability in the
    VM.
-   Note: This may stop programs like Docker Desktop and WSL 2 from
+   
+   **Note:**
+   This may stop programs like Docker Desktop and WSL 2 from
    working. If these programs are essential to your workflow, consider
    looking up how to add a separate boot entry with "hypervisorlaunchtype"
    set to "off" for use with VirtualBox.

--- a/_docs/developer/vm_install_using_vagrant.md
+++ b/_docs/developer/vm_install_using_vagrant.md
@@ -37,7 +37,16 @@ instructions.
    shutting down the VMWare VMs, or stopping the VMWare services, or
    uninstalling VMWare.
 
-4. The complete installation process could take an hour or more.  Make
+4. If you're running Windows, it is recommended to disable Hyper-V.
+   Leaving it enabled will force VirtualBox to use the Hyper-V
+   backend, which will be slower and can cause instability in the
+   VM.
+   Note: This may stop programs like Docker Desktop and WSL 2 from
+   working. If these programs are essential to your workflow, consider
+   looking up how to add a separate boot entry with "hypervisorlaunchtype"
+   set to "off" for use with VirtualBox.
+
+5. The complete installation process could take an hour or more.  Make
    sure your internet connection is strong and consistent.  You'll
    probably want to plug in your laptop power cord.  Check your
    computer settings and make sure the machine does not hibernate or


### PR DESCRIPTION
When running VirtualBox with Hyper-V installed, it forces VirtualBox to run with the Hyper-V backend. This can cause system instability inside of the VM, which can lead to unpredictable behavior which can be difficult to debug.

This adds a recommendation to disable Hyper-V, with a note to lookup how to add a separate boot entry should a developer want a way to quickly boot into Windows with and without Hyper-V enabled.