### PR TITLE
[Documentation:Developer] Use flag for brew cask installs

### DIFF
--- a/_docs/developer/testing/site_end_to_end_tests.md
+++ b/_docs/developer/testing/site_end_to_end_tests.md
@@ -35,7 +35,7 @@ page from the above link.
 
 For Mac, using homebrew:
 ```
-brew install chromedriver
+brew install --cask chromedriver
 ```
 
 For Linux, use:

--- a/_docs/developer/testing/site_end_to_end_tests.md
+++ b/_docs/developer/testing/site_end_to_end_tests.md
@@ -35,7 +35,7 @@ page from the above link.
 
 For Mac, using homebrew:
 ```
-brew cask install chromedriver
+brew install chromedriver
 ```
 
 For Linux, use:

--- a/_docs/developer/vm_install_using_vagrant.md
+++ b/_docs/developer/vm_install_using_vagrant.md
@@ -115,8 +115,8 @@ instructions.
      install [homebrew](http://brew.sh/)    if you don't have it and then run:
 
      ```
-     brew cask install virtualbox
-     brew cask install vagrant
+     brew install virtualbox
+     brew install vagrant
      ```
 
    **Ubuntu/Debian**
@@ -370,8 +370,8 @@ instructions.
     For example, on Mac:
 
     ```
-    brew cask reinstall virtualbox
-    brew cask reinstall vagrant
+    brew reinstall virtualbox
+    brew reinstall vagrant
     vagrant plugin update
     vagrant box update
     ```
@@ -417,4 +417,3 @@ instructions.
    **NOTE**
    Especially for mobile operating systems, make sure that your SSH client supports SSH port forwarding. On iOS, you will also have to enable location tracking for the client to keep the connection alive in the background.
 
-6. Navigate to `localhost:1501` on the remote device.

--- a/_docs/developer/vm_install_using_vagrant.md
+++ b/_docs/developer/vm_install_using_vagrant.md
@@ -417,3 +417,4 @@ instructions.
    **NOTE**
    Especially for mobile operating systems, make sure that your SSH client supports SSH port forwarding. On iOS, you will also have to enable location tracking for the client to keep the connection alive in the background.
 
+6. Navigate to `localhost:1501` on the remote device.

--- a/_docs/developer/vm_install_using_vagrant.md
+++ b/_docs/developer/vm_install_using_vagrant.md
@@ -115,8 +115,8 @@ instructions.
      install [homebrew](http://brew.sh/)    if you don't have it and then run:
 
      ```
-     brew install virtualbox
-     brew install vagrant
+     brew install --cask virtualbox
+     brew install --cask vagrant
      ```
 
    **Ubuntu/Debian**
@@ -370,8 +370,8 @@ instructions.
     For example, on Mac:
 
     ```
-    brew reinstall virtualbox
-    brew reinstall vagrant
+    brew reinstall --cask virtualbox
+    brew reinstall --cask vagrant
     vagrant plugin update
     vagrant box update
     ```


### PR DESCRIPTION
Cask recently became an official part of the Homebrew project.  As such, it is no longer necessary to add `cask` when installing packages.