### PR TITLE
[Documentation:Developer] Fix controller example

### DIFF
--- a/_docs/developer/developing_the_php_site/controller.md
+++ b/_docs/developer/developing_the_php_site/controller.md
@@ -6,19 +6,19 @@ category: Developer
 The Controller is part of the [Model-View-Controller](index) software
 design pattern.
 
-The Controller act as the gateway for taking in a user's request,
+The Controller acts as the gateway for taking in a user's request,
 collecting the data from a [Model](model), and passing it along to the
 appropriate [View](view).
 
 ## Example: User Controller
 
-So a request to view the `UserDetails` page would first hit the
+A request to view the `UserDetails` page would first hit the
 `UserController`, which might look something like this:
 
 ```PHP
 /**
 * Route to view the userDetailsPage.
-* @Route("/{semester}/{course}/show_user_details", methods={"GET"})
+* @Route("/{_semester}/{_course}/show_user_details", methods={"GET"})
 * @AccessControl(role="INSTRUCTOR")
 **/
 


### PR DESCRIPTION
Example controller under the "developing the PHP site" section was missing underscores for the `_semester` and `_course` which is required for the variable replacement to occur. 

Also 2 minor grammar fixes. 