### PR TITLE
[Documentation:System] Update Worker SSH Instructions

### DIFF
--- a/_docs/sysadmin/worker_installation.md
+++ b/_docs/sysadmin/worker_installation.md
@@ -72,7 +72,7 @@ _Note: These instructions should be run under root/sudo._
    ___NOTE: The ssh-copy-id line requires a replacement___
    ```
    su submitty_daemon
-   cd ~/.ssh
+   cd ~/
    ssh-keygen
    ssh-copy-id -i ~/.ssh/id_rsa.pub SUBMITTY_USER@HOSTNAME
    ```


### PR DESCRIPTION
Removes step changing directory into `~/.ssh` folder since it may not always exist. Instead, you can just `cd ~/` and run `ssh-keygen` which will make the folder if it doesn't exist, and if it does exist it will place the key in that folder.