### PR TITLE
[Documentation:Developer] Add calendar module

### DIFF
--- a/_docs/developer/how_to_contribute.md
+++ b/_docs/developer/how_to_contribute.md
@@ -67,6 +67,7 @@ Be sure to read the [Suggestions for New Developers](/developer#suggestions-for-
       * `CourseMaterials`,  
       * `Plagiarism`,  
       * `RainbowGrades`,  
+      * `Calendar`,  
       * `System` (includes installation, migrations, vagrant),
       * `Developer`, or
       * `API`


### PR DESCRIPTION
Adds calendar module to be introduced into the title checker in https://github.com/Submitty/action-pr-title/pull/6.