### PR TITLE
[Documentation:System] Update docs to mention LDAP

### DIFF
--- a/_docs/developer/development_instructions/miscellaneous.md
+++ b/_docs/developer/development_instructions/miscellaneous.md
@@ -4,15 +4,25 @@ category: Developer
 ---
 
 
-## Pam vs. Database Authentication
+## Testing Authentication
 
 Our vagrant environment defaults to PAM authentication, but is also
-setup to use database authentication.
+setup to easily use any of the other supported authentication methods.
 
 To switch, either re-run CONFIGURE_SUBMITTY.py or edit
-`/usr/local/submitty/config/database.json` and change the
-authentication method from `PamAuthentication` to
-`DatabaseAuthentication`.
+`/usr/local/submitty/config/authentication.json` and change the
+authentication method to any of the methods. You should be able
+to leave all other settings to the default.
+
+For `LdapAuthentication`, the default settings are:
+
+```json
+"ldap_options": {
+    "url": "ldap://localhost",
+    "uid": "uid",
+    "bind_dn": "ou=users,dc=vagrant,dc=local"
+}
+```
 
 When using DatabaseAuthentication, Submitty allows users to
 [change their password](/student/account/password) from the home screen.

--- a/_docs/sysadmin/installation.md
+++ b/_docs/sysadmin/installation.md
@@ -32,7 +32,7 @@ _Note: These instructions should be run under root/sudo._
    ```
    bash -c "$(curl -s https://raw.githubusercontent.com/Submitty/Submitty/master/.setup/bootstrap.sh)"
    ```
-   
+
    or clone the git repository and run the installer (requires git and lsb-release to be installed):
 
    ```
@@ -54,11 +54,11 @@ _Note: These instructions should be run under root/sudo._
    4. **Main Site URL**.
    5. **Version Control System (VCS) URL**. This is used mostly to allow students to submit their homework through private repositories hosted on the submitty server. See [Facilitating Student Submissions via GIT](/instructor/managing_git).
    6. **Institution Name**.
-   7. **Authentication Method (PAM or Database)**. PAM authentication requires the sysadmin to make accounts ahead of time for students and give them a password. Database authentication lets students create their own passwords. 
+   7. **Authentication Method**. PAM and LDAP authentication requires the sysadmin to make accounts ahead of time for students and give them a password. Database authentication lets students create their own passwords.
 
 
-   
-3. Run installations specific to your university.  
+
+3. Run installations specific to your university.
    For example:  [RPI Computer Science specific installations](https://github.com/Submitty/Submitty/blob/master/.setup/distro_setup/ubuntu/rpi.sh)
 
    ```


### PR DESCRIPTION
Basic documentation PR for https://github.com/Submitty/Submitty/pull/6482.

We may wish to create a new sysadmin page that specifically covers authentication methods as we LDAP here and think about adding support for CAS in the future. Thoughts @bmcutler?