### PR TITLE
[Documentation:Developer] Remove need to specify php conf files

### DIFF
--- a/_docs/developer/coding_style_guide/php.md
+++ b/_docs/developer/coding_style_guide/php.md
@@ -19,14 +19,14 @@ which handles installing the dependencies and setting up the
 To run `phpcs`, you can use the following command:
 
 ```bash
-php vendor/bin/phpcs --standard=tests/ruleset.xml [path/to/file/or/directory]
+php vendor/bin/phpcs [path/to/file/or/directory]
 ```
 
 where if you leave off the path, it will analyze all files and directories for Submitty.
 Additionally, you can apply the automatic fixer to your code by running:
 
 ```bash
-php vendor/bin/phpcbf --standard=tests/ruleset.xml [path/to/file/or/directory]
+php vendor/bin/phpcbf [path/to/file/or/directory]
 ```
 
 ### Classes, Methods

--- a/_docs/developer/phpstorm.md
+++ b/_docs/developer/phpstorm.md
@@ -94,7 +94,7 @@ Under PhpStorm settings, open `Languages & Frameworks` > `PHP` > `Test Framework
 - `PHPUnit Library`: `Use Composer autoloader`
 - `Path to script`: `/usr/local/submitty/GIT_CHECKOUT/Submitty/site/vendor/autoloader.php`
 - Hit the arrows button to confirm that it can find PHPUnit
-- `Default Configuration File`: `/usr/local/submitty/GIT_CHECKOUT/Submitty/site/tests/phpunit.xml`
+- `Default Configuration File`: `/usr/local/submitty/GIT_CHECKOUT/Submitty/site/phpunit.xml`
 
 Press `OK` to save the test configuration.
 

--- a/_docs/developer/testing/linting_static_analysis.md
+++ b/_docs/developer/testing/linting_static_analysis.md
@@ -46,17 +46,17 @@ If you are running on WSL and are seeing errors, remove "`php`" from the followi
 
 ```bash
 # from root level of Submitty repository
-php site/vendor/bin/phpcs --standard=site/tests/ruleset.xml
+php site/vendor/bin/phpcs
 
 # or if in the site/ directory of the Submitty
-php vendor/bin/phpcs --standard=tests/ruleset.xml
+php vendor/bin/phpcs
 ```
 
 Similarly, you can pass a specific file or directory to `phpcs`, e.g:
 
 ```bash
 # from root level of Submitty repository...  run phpcs against all files in this subdirectory
-php site/vendor/bin/phpcs --standard=site/tests/ruleset.xml site/app/controllers/student/
+php site/vendor/bin/phpcs site/app/controllers/student/
 ```
 
 See also: [PHP Style Guide](/developer/coding_style_guide/php)

--- a/_docs/developer/testing/php_unit_tests.md
+++ b/_docs/developer/testing/php_unit_tests.md
@@ -15,14 +15,14 @@ To run the PHP unit test suite locally, `cd` to the `Submitty/site` directory an
 If you are running on WSL and are seeing errors, remove "`php`" from the following commands.
 
 ```
-php vendor/bin/phpunit --configuration tests/phpunit.xml
+php vendor/bin/phpunit
 ```
 
 To run just an individual class or test, you can use the `--filter` flag on PHPUnit.
 For example, to run the function `testInvalidProperty` would be
-`php vendor/bin/phpunit -c tests/phpunit.xml --filter testInvalidProperty` and running all
+`php vendor/bin/phpunit --filter testInvalidProperty` and running all
 of `AccessControlTester` would be
-`php vendor/bin/phpunit -c tests/phpunit.xml --filter AccessControlTester`. Be aware, filter
+`php vendor/bin/phpunit--filter AccessControlTester`. Be aware, filter
 can match against partial strings, so if you have two tests `testFoo` and `testFooBar`,
 running `--filter testFoo` will run them both. Alternatively, you can also directly run
 `phpunit` against a specific class by passing the path to the test class directly to
@@ -34,7 +34,7 @@ The two concepts above can be combined to run a specific test function in a spec
 class by doing:
 
 ```bash
-vendor/bin/phpunit -c tests/phpunit.xml --filter testFunction tests/app/path/to/TestClass.php
+vendor/bin/phpunit --filter testFunction tests/app/path/to/TestClass.php
 ```
 
 You can pass in the `--debug` flag when using PHPUnit to see PHP output, this can be


### PR DESCRIPTION
Docs PR for https://github.com/Submitty/Submitty/pull/7303. The files have been moved so it's no longer necessary to specify the configuration file for running phpunit or phpcs.