### PR TITLE
[Documentation:System] Add documentation for Node.js update

### DIFF
--- a/_docs/sysadmin/version_notes/v21.11.01.md
+++ b/_docs/sysadmin/version_notes/v21.11.01.md
@@ -15,6 +15,9 @@ deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/no
 deb-src [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x focal main
 ```
 
+Replace `focal` above with whatever the name of Ubuntu you are running. You can get this information by
+running `lsb_release -cs` in the terminal.
+
 After editing the file, the system must be updated by running the following
 commands:
 ```

--- a/_docs/sysadmin/version_notes/v21.11.01.md
+++ b/_docs/sysadmin/version_notes/v21.11.01.md
@@ -2,7 +2,6 @@
 title:  v21.11.01 -- Update Node.js to 16.x
 ---
 
-
 Release [v21.11.01](https://github.com/Submitty/Submitty/releases/v21.11.01)
 updates the version of Node.js to 16.x.  Doing this on existing Submitty
 instances requires the file `/etc/apt/sources.list.d/nodesource.list` to be

--- a/_docs/sysadmin/version_notes/v21.11.01.md
+++ b/_docs/sysadmin/version_notes/v21.11.01.md
@@ -10,6 +10,7 @@ manually edited to update the version of Node.js.  The current version of Node.j
 may be determined by running `node -v`.
 
 The file should be edited to the following:
+
 ```
 deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x focal main
 deb-src [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x focal main
@@ -20,7 +21,8 @@ running `lsb_release -cs` in the terminal.
 
 After editing the file, the system must be updated by running the following
 commands:
-```
+
+```bash
 sudo apt-get update
 sudo apt-get upgrade
 ```

--- a/_docs/sysadmin/version_notes/v21.11.01.md
+++ b/_docs/sysadmin/version_notes/v21.11.01.md
@@ -1,0 +1,25 @@
+---
+title:  v21.11.01 -- Update Node.js to 16.x
+---
+
+
+Release [v21.11.01](https://github.com/Submitty/Submitty/releases/v21.11.01)
+updates the version of Node.js to 16.x.  Doing this on existing Submitty
+instances requires the file `/etc/apt/sources.list.d/nodesource.list` to be
+manually edited to update the version of Node.js.  The current version of Node.js
+may be determined by running `node -v`.
+
+The file should be edited to the following:
+```
+deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x focal main
+deb-src [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x focal main
+```
+
+After editing the file, the system must be updated by running the following
+commands:
+```
+sudo apt-get update
+sudo apt-get upgrade
+```
+
+The new version of Node.js can be verified by running `node -v`.


### PR DESCRIPTION
https://github.com/Submitty/Submitty/pull/7320 includes changes to update the version of Node.js to 16.x.  This PR includes instructions for the upcoming 21.11.01 release of Submitty which will tentatively include this sysadmin action.