### PR TITLE
[Documentation:Developer] esbuild for ES6 modules and TypeScript

### DIFF
--- a/_docs/developer/developing_the_php_site/javascript.md
+++ b/_docs/developer/developing_the_php_site/javascript.md
@@ -1,6 +1,10 @@
 ---
-title: ES6 Modules and Typescript
+title: Frontend JavaScript
 ---
+
+On the frontend, Submitty uses JavaScript to allow for interactivity with the site. Historically, the JS code was written
+and imported globally and that lives in the `site/public/js` folder. However, embracing modern standards, we are increasingly
+looking to write all new frontend code as ES6 modules.
 
 [ES6 Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) allow JavaScript code to be split up
 into "modules" that can allow other modules to import functions and variables. Modules in Submitty are loaded the 

--- a/_docs/developer/developing_the_php_site/modules.md
+++ b/_docs/developer/developing_the_php_site/modules.md
@@ -4,19 +4,48 @@ title: ES6 Modules and Typescript
 
 [ES6 Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) allow JavaScript code to be split up
 into "modules" that can allow other modules to import functions and variables. Modules in Submitty are loaded the 
-same way as normal JavaScript files using the PHP function `$this->core->getOutput()->addInternalJs(...)`. Unlike normal 
+same way as normal JavaScript files using the PHP function `$this->output->addInternalJs(...)`. Unlike normal 
 JavaScript, modules are "bundled" together by esbuild. This process takes all files imported and creates a single, 
 minified JavaScript file that is served to the user.
+
+Unlike regular JS files, ES6 modules are not included into the global JS scope, and are self-contained. When a module is executed, it only has access to functions that it imports, and that the HTML cannot call functions defined within modules. As such, to hook a function defined in a module to something in the DOM, such as a click event listener, you will need to use the addEventListener API. This seperation of regular JS and modules also extends to HTML, attributes such as `onclick` and other inline event handlers cannot call functions defined in modules even if they are exported. 
 
 JavaScript modules are places in the `Submitty/site/ts` directory and running the install script will launch esbuild
 and bundle files, the output will be places in the `Submitty/site/mjs` directory. You can run the command 
 `npm run build` to manually bundle files after running `npm install` from the `Submitty/site` directory.
 
 `npm run build` uses node to run the `Submitty/site/.build.js` file, this contains the logic for searching which files
-to transpile and the configuration for esbuild.
+to transpile and bundle, along with the configuration for esbuild.
+
+## Creating new modules
+
+Any new module written should be a `.ts` file to take advantage the type safety of TypeScript. Top levels files
+under the `ts` directory are considered entry points and once bundled will create a corresponding `.js` file under
+the `public/mjs` directory along with a sourcemap. Support files for your module can be created under a new 
+directory in the `ts` area, like the `utils` directory. On the PHP side, you will then only need
+to include the single corresponding `mjs` file to your top level entry point file. This has the advantage of reducing the number of files sent to the client.
 
 ## TypeScript
 
 [TypeScript](https://www.typescriptlang.org/) is a superset of JavaScript that allows strongly typed syntax which is 
 then transpiled into normal JavaScript. Any file with the `.ts` file type will be transpiled by esbuild as part of the 
 `npm run build` command and Submitty install script.
+
+
+## Loading JavaScript files
+
+Once a module or regular JavaScript file is written it needs to be served to the user and included by the HTML. This is done in PHP through the `addInternalModuleJs` and `addInternalJS`. Each function takes a target filename which is then sent to the user and timestamped to prevent browsers from caching old versions. These functions are defined in the `site/app/libraries/Output.php`.
+
+Both functions work similarly but the `addInternalJS` searches the `site/public/js` directory and `addInternalModuleJs` searches the `site/public/mjs` directory.
+
+E.g:
+
+```php
+// searches the site/public/mjs area, its source file would be site/ts/foo.ts
+$this->output->addInternalModuleJs('foo.js');
+```
+
+```php
+// searches the site/public/js area
+$this->output->addInternalJS('foo.js');
+```

--- a/_docs/developer/developing_the_php_site/modules.md
+++ b/_docs/developer/developing_the_php_site/modules.md
@@ -8,10 +8,14 @@ same way as normal JavaScript files using the PHP function `$this->output->addIn
 JavaScript, modules are "bundled" together by esbuild. This process takes all files imported and creates a single, 
 minified JavaScript file that is served to the user.
 
-Unlike regular JS files, ES6 modules are not included into the global JS scope, and are self-contained. When a module is executed, it only has access to functions that it imports, and that the HTML cannot call functions defined within modules. As such, to hook a function defined in a module to something in the DOM, such as a click event listener, you will need to use the addEventListener API. This seperation of regular JS and modules also extends to HTML, attributes such as `onclick` and other inline event handlers cannot call functions defined in modules even if they are exported. 
+Unlike regular JS files, ES6 modules are not included into the global JS scope, and are self-contained. When a module is
+executed, it only has access to the things that it imports, and we cannot call functions defined within modules directly from
+the DOM. As such, to hook a function defined in a module to something in the DOM, such as a click event listener, you will need to 
+use the addEventListener API. This seperation of regular JS and modules also extends to HTML, attributes such as `onclick`
+and other inline event handlers cannot call functions defined in modules even if they are exported. 
 
-JavaScript modules are places in the `Submitty/site/ts` directory and running the install script will launch esbuild
-and bundle files, the output will be places in the `Submitty/site/mjs` directory. You can run the command 
+JavaScript modules are placed in the `Submitty/site/ts` directory and running the install script will launch esbuild
+and bundle files, the output will be placed in the `Submitty/site/mjs` directory. You can run the command 
 `npm run build` to manually bundle files after running `npm install` from the `Submitty/site` directory.
 
 `npm run build` uses node to run the `Submitty/site/.build.js` file, this contains the logic for searching which files
@@ -23,7 +27,8 @@ Any new module written should be a `.ts` file to take advantage the type safety 
 under the `ts` directory are considered entry points and once bundled will create a corresponding `.js` file under
 the `public/mjs` directory along with a sourcemap. Support files for your module can be created under a new 
 directory in the `ts` area, like the `utils` directory. On the PHP side, you will then only need
-to include the single corresponding `mjs` file to your top level entry point file. This has the advantage of reducing the number of files sent to the client.
+to include the single corresponding `mjs` file to your top level entry point file. This has the advantage of
+reducing the number of files sent to the client.
 
 ## TypeScript
 
@@ -34,9 +39,13 @@ then transpiled into normal JavaScript. Any file with the `.ts` file type will b
 
 ## Loading JavaScript files
 
-Once a module or regular JavaScript file is written it needs to be served to the user and included by the HTML. This is done in PHP through the `addInternalModuleJs` and `addInternalJS`. Each function takes a target filename which is then sent to the user and timestamped to prevent browsers from caching old versions. These functions are defined in the `site/app/libraries/Output.php`.
+Once a module or regular JavaScript file is written it needs to be served to the user and included by the HTML. This is
+done in PHP through the `addInternalModuleJs` and `addInternalJS`. Each function takes a target filename which is then
+sent to the user and timestamped to prevent browsers from caching old versions. These functions are defined in the
+`site/app/libraries/Output.php`.
 
-Both functions work similarly but the `addInternalJS` searches the `site/public/js` directory and `addInternalModuleJs` searches the `site/public/mjs` directory.
+Both functions work similarly but the `addInternalJS` searches the `site/public/js` directory and `addInternalModuleJs`
+searches the `site/public/mjs` directory.
 
 E.g:
 

--- a/_docs/developer/developing_the_php_site/modules.md
+++ b/_docs/developer/developing_the_php_site/modules.md
@@ -1,0 +1,22 @@
+---
+title: ES6 Modules and Typescript
+---
+
+[ES6 Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) allow JavaScript code to be split up
+into "modules" that can allow other modules to import functions and variables. Modules in Submitty are loaded the 
+same way as normal JavaScript files using the PHP function `$this->core->getOutput()->addInternalJs(...)`. Unlike normal 
+JavaScript, modules are "bundled" together by esbuild. This process takes all files imported and creates a single, 
+minified JavaScript file that is served to the user.
+
+JavaScript modules are places in the `Submitty/site/ts` directory and running the install script will launch esbuild
+and bundle files, the output will be places in the `Submitty/site/mjs` directory. You can run the command 
+`npm run build` to manually bundle files after running `npm install` from the `Submitty/site` directory.
+
+`npm run build` uses node to run the `Submitty/site/.build.js` file, this contains the logic for searching which files
+to transpile and the configuration for esbuild.
+
+## TypeScript
+
+[TypeScript](https://www.typescriptlang.org/) is a superset of JavaScript that allows strongly typed syntax which is 
+then transpiled into normal JavaScript. Any file with the `.ts` file type will be transpiled by esbuild as part of the 
+`npm run build` command and Submitty install script.

--- a/navtreedata.js
+++ b/navtreedata.js
@@ -205,7 +205,7 @@ var NAVTREE =
                 [ "Controller", "/developer/developing_the_php_site/controller", null ],
                 [ "Feature Flags", "/developer/developing_the_php_site/feature_flags", null ],
                 [ "WebSocket", "/developer/developing_the_php_site/websocket", null ],
-                [ "ES6 Modules & TypeScript", "/developer/developing_the_php_site/modules", null]
+                [ "Frontend JavaScript", "/developer/developing_the_php_site/javascript", null]
             ] ],
             [ "Updating Dependencies", "/developer/updating_dependencies", null ],
             [ "Configuring Tie In Programs", "/developer/configuring_tie_in_programs", null ],

--- a/navtreedata.js
+++ b/navtreedata.js
@@ -204,7 +204,8 @@ var NAVTREE =
                 [ "View", "/developer/developing_the_php_site/view", null ],
                 [ "Controller", "/developer/developing_the_php_site/controller", null ],
                 [ "Feature Flags", "/developer/developing_the_php_site/feature_flags", null ],
-                [ "WebSocket", "/developer/developing_the_php_site/websocket", null ]
+                [ "WebSocket", "/developer/developing_the_php_site/websocket", null ],
+                [ "ES6 Modules & TypeScript", "/developer/developing_the_php_site/modules", null]
             ] ],
             [ "Updating Dependencies", "/developer/updating_dependencies", null ],
             [ "Configuring Tie In Programs", "/developer/configuring_tie_in_programs", null ],


### PR DESCRIPTION
The following PR adds documentation on how Submitty uses esbuild to bundle es6 and typescript files into our system.

https://github.com/Submitty/Submitty/pull/7285