### PR TITLE
[Documentation:Developer] Update minimum version for PHP/Python

### DIFF
--- a/_docs/developer/software_and_system_design/coding_style_guide/php.md
+++ b/_docs/developer/software_and_system_design/coding_style_guide/php.md
@@ -5,7 +5,7 @@ redirect_from:
   - /developer/coding_style_guide/php
 ---
 
-__Minimum Version__: 7.2
+__Minimum Version__: 7.4
 
 For PHP, we use a foundation of [PSR-1](https://www.php-fig.org/psr/psr-1/) and
 [PSR-12](https://www.php-fig.org/psr/psr-12/), with some slight modifications on

--- a/_docs/developer/software_and_system_design/coding_style_guide/python.md
+++ b/_docs/developer/software_and_system_design/coding_style_guide/python.md
@@ -5,7 +5,7 @@ redirect_from:
   - /developer/coding_style_guide/python
 ---
 
-__Minimum Version__: 3.6
+__Minimum Version__: 3.8
 
 For Python, we use [flake8](http://flake8.pycqa.org/en/latest/) to check Python code such that it follows things laid out in
 [PEP-8](https://www.python.org/dev/peps/pep-0008/), [PEP-257](https://www.python.org/dev/peps/pep-0257/), etc. The code is


### PR DESCRIPTION
This PR updates the listed minimum version for PHP (`7.2` -> `7.4`) and Python (`3.6` -> `3.8`) since we've dropped support for Ubuntu 18.04 as part of https://github.com/Submitty/Submitty/pull/7925, and these are the versions of those languages included in Ubuntu 20.04.