### PR TITLE
[Documentation:System] Disk space update on VM install

### DIFF
--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -28,7 +28,7 @@ instructions.
    also required (most computers have these).  Submitty is RAM and I/O
    intensive, so more RAM and a fast disk are better.
 
-2. Make sure you have at least 20GB of hard disk available for
+2. Make sure you have at least 65GB of hard disk available for
    installation.  We do not recommend installing the Submitty
    Developer VM on DropBox, OneDrive, GoogleDrive, or other cloud
    storage.


### PR DESCRIPTION
Pre-Installation Checklist states that 20GB of disk space should be available.  Current VM takes more than 61GB, and it slightly varies depending on OS.