### PR TITLE
[Documentation:Developer] Updated Vagrant Link for Linux

### DIFF
--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -133,7 +133,8 @@ instructions.
 
      VirtualBox: <https://www.virtualbox.org/wiki/Linux_Downloads>
 
-     Vagrant: <https://vagrant-deb.linestarve.com/>
+     Vagrant: <https://developer.hashicorp.com/vagrant/downloads> 
+     (if that doesn't work, try: <https://vagrant-deb.linestarve.com/>)
 
 5. Clone [the Submitty repository](https://github.com/Submitty/Submitty) to a location on
    your computer (the "host").


### PR DESCRIPTION
Vagrant now natively supports Linux, so https://vagrant-deb.linestarve.com/ is no longer necessary. 

I have updated the link to show Vagrant's official download link. I have kept the old link in case it would be needed.