### PR TITLE
[Documentation:Autograding] Add max submission size

### DIFF
--- a/_docs/instructor/autograding/specification.md
+++ b/_docs/instructor/autograding/specification.md
@@ -25,6 +25,12 @@ executables.
   **type:** _string_  
   **default value:** ``""``
 
+* **field** ``"max_submission_size"``  
+  **type:** _integer_  
+  **default value:** 100000
+
+  This is the max size in bytes of all files combined for a website submission.
+
 
 * **field:** ``"grading_parameters"``  
   **type:** _associative array / mapping from string to integer_


### PR DESCRIPTION
Add info on the instructor pages about max submission size config. It is currently only in the system admin area of the docs.