### PR TITLE
[Documentation:Developer] Fix ARM Mac page styling

### DIFF
--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -21,6 +21,14 @@ instructions.
 
 ---
 
+_IMPORTANT NOTE: If you are using an Apple Mac computer
+with [Apple Silicon (e.g., M1 or M2)](https://support.apple.com/en-us/HT211814),
+first released in late 2020, you will follow
+the [Vagrant QEMU instructions](/developer/getting_started/vm_install_using_vagrant_apple_silicon).
+If you using an Intel-based Mac, you will follow the instructions below._
+
+---
+
 ## Pre-Installation Checklist
 
 1. To develop with a Virtual Machine (VM), your computer should have
@@ -61,17 +69,6 @@ instructions.
    go to sleep during installation.
 
 ---
-
-
-_IMPORTANT NOTE: If you are using an Apple Mac computer
-with [Apple Silicon (e.g., M1 or M2)](https://support.apple.com/en-us/HT211814),
-first released in late 2020, you will follow
-the [Vagrant QEMU instructions](/developer/getting_started/vm_install_using_vagrant_apple_silicon).
-If you using an Intel-based Mac, you will follow the instructions below._
-
-
----
-
 
 ## Submitty Developer VM Installation
 

--- a/_docs/developer/getting_started/vm_install_using_vagrant_apple_silicon.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant_apple_silicon.md
@@ -16,7 +16,7 @@ architecture.
 
 ---
 
-### Requirements
+## Requirements
 
 1. Make sure you have an Apple Silicon Mac running macOS Monterey
 (12.4) or higher.
@@ -31,7 +31,7 @@ the installation process.
 
 ---
 
-### Pre-Installation Steps
+## Pre-Installation Steps
 
 1. Enable SMB file sharing
 
@@ -43,7 +43,7 @@ the installation process.
 
 ---
 
-### Installation
+## Installation
 
 1. Install [Homebrew](https://brew.sh/)
    ```
@@ -169,6 +169,6 @@ the installation process.
 ---
 
 
-### Now you can continue with the regular development instructions...
+## Now you can continue with the regular development instructions...
 
 [Using your Submitty Developer VM](vm_install_using_vagrant#using-your-submitty-developer-vm)


### PR DESCRIPTION
Updates the header styling in the ARM Mac setup instructions page to fix duplicate rules and be more consistent with the other vagrant page. Moves up the notice in the other vagrant page.