### PR TITLE
[Documentation:Developer] Information on disabling wsl2

### DIFF
--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -190,7 +190,7 @@ Below are quick steps to get everything installed and running.
    few hours depending on your Internet connection speed.  When this
    command finishes, your VM is ready to use.
 
-   On **Windows 10**: If `vagrant up` stays stuck on `SSH auth method: private key`
+   **On Windows 10**: If `vagrant up` stays stuck on `SSH auth method: private key`
    for more than 5 minutes, it is likely WSL2 or hypervisor is still
    installed. See [this page]("https://learn.microsoft.com/en-us/troubleshoot/
    windows-client/application-management/virtualization-apps-not-work-with-hyper-v")

--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -192,8 +192,7 @@ Below are quick steps to get everything installed and running.
 
    **On Windows 10**: If `vagrant up` stays stuck on `SSH auth method: private key`
    for more than 5 minutes, it is likely WSL2 or hypervisor is still
-   installed. See [this page]("https://learn.microsoft.com/en-us/troubleshoot/
-windows-client/application-management/virtualization-apps-not-work-with-hyper-v")
+   installed. See [this page]("https://learn.microsoft.com/en-us/troubleshoot/windows-client/application-management/virtualization-apps-not-work-with-hyper-v")
    for how to turn off hypervisor in the Control Panel. In the same
    "Turn Windows features on or off" window, uncheck "Virtual Machine Platform"
    to disable WSL2. This will restart your computer. After the restart,

--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -196,7 +196,7 @@ Below are quick steps to get everything installed and running.
    for how to turn off hypervisor in the Control Panel. In the same
    "Turn Windows features on or off" window, uncheck "Virtual Machine Platform"
    to disable WSL2. This will restart your computer. After the restart,
-   try `vagrant up` again and it should continue past `SSH auth method: private key`.
+   try `vagrant up` again and it should likely continue past `SSH auth method: private key`.
 
 7. When the `vagrant up` command completes successfully, you will be
    able to access the Submitty website (instructions follow in the

--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -193,7 +193,7 @@ Below are quick steps to get everything installed and running.
    **On Windows 10**: If `vagrant up` stays stuck on `SSH auth method: private key`
    for more than 5 minutes, it is likely WSL2 or hypervisor is still
    installed. See [this page]("https://learn.microsoft.com/en-us/troubleshoot/
-   windows-client/application-management/virtualization-apps-not-work-with-hyper-v")
+windows-client/application-management/virtualization-apps-not-work-with-hyper-v")
    for how to turn off hypervisor in the Control Panel. In the same
    "Turn Windows features on or off" window, uncheck "Virtual Machine Platform"
    to disable WSL2. This will restart your computer. After the restart,

--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -192,8 +192,7 @@ Below are quick steps to get everything installed and running.
 
    **On Windows 10**: If `vagrant up` stays stuck on `SSH auth method: private key`
    for more than 5 minutes, it is likely WSL2 or hypervisor is still
-   installed. See [this page](https://learn.microsoft.com/en-us/troubleshoot/
-   windows-client/application-management/virtualization-apps-not-work-with-hyper-v)
+   installed. See [this page](https://learn.microsoft.com/en-us/troubleshoot/windows-client/application-management/virtualization-apps-not-work-with-hyper-v)
    for how to turn off hypervisor in the Control Panel. In the same
    "Turn Windows features on or off" window, uncheck "Virtual Machine Platform"
    to disable WSL2. This will restart your computer. After the restart,

--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -192,7 +192,8 @@ Below are quick steps to get everything installed and running.
 
    **On Windows 10**: If `vagrant up` stays stuck on `SSH auth method: private key`
    for more than 5 minutes, it is likely WSL2 or hypervisor is still
-   installed. See [this page]("https://learn.microsoft.com/en-us/troubleshoot/windows-client/application-management/virtualization-apps-not-work-with-hyper-v")
+   installed. See [this page](https://learn.microsoft.com/en-us/troubleshoot/
+   windows-client/application-management/virtualization-apps-not-work-with-hyper-v)
    for how to turn off hypervisor in the Control Panel. In the same
    "Turn Windows features on or off" window, uncheck "Virtual Machine Platform"
    to disable WSL2. This will restart your computer. After the restart,

--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -190,6 +190,15 @@ Below are quick steps to get everything installed and running.
    few hours depending on your Internet connection speed.  When this
    command finishes, your VM is ready to use.
 
+   On **Windows 10**: If `vagrant up` stays stuck on `SSH auth method: private key`
+   for more than 5 minutes, it is likely WSL2 or hypervisor is still
+   installed. See [this page]("https://learn.microsoft.com/en-us/troubleshoot/
+   windows-client/application-management/virtualization-apps-not-work-with-hyper-v")
+   for how to turn off hypervisor in the Control Panel. In the same
+   "Turn Windows features on or off" window, uncheck "Virtual Machine Platform"
+   to disable WSL2. This will restart your computer. After the restart,
+   try `vagrant up` again and it should continue past `SSH auth method: private key`.
+
 7. When the `vagrant up` command completes successfully, you will be
    able to access the Submitty website (instructions follow in the
    next section).


### PR DESCRIPTION
When installing Submitty via Vagrant on Windows, a common issue is having WSL2 or hypervisor enabled. In the VM Install using Vagrant page, I added extra information after the `vagrant up` command on how to get past a common roadblock.