### PR TITLE
[Documentation:Developer] Removed duplicate installation steps

### DIFF
--- a/_docs/developer/development_instructions/automated_grading.md
+++ b/_docs/developer/development_instructions/automated_grading.md
@@ -95,7 +95,7 @@ number:
 
 2. Setting up the worker machine(s):
 
-   Follow the [worker installation instructions](https://submitty.org/sysadmin/installation/worker_installation)
+   Follow the [worker installation instructions](/sysadmin/installation/worker_installation)
 
 
 3. Next, create homework assignment autograding configurations that


### PR DESCRIPTION
There are incomplete and duplicate steps under "Developer > Advanced Development > Automated Grading" on the documentation page.

I created a link to redirect the installation to "System Administrator > Installation"

Before:
![image](https://github.com/Submitty/submitty.github.io/assets/46644513/267cab97-bec2-412f-8c3d-259a770ad73d)

After:
![image](https://github.com/Submitty/submitty.github.io/assets/46644513/e267f3f0-dc2b-4856-af82-06b4714fd149)
