### PR TITLE
[Documentation:Developer] Update date in footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -77,7 +77,7 @@
             <footer>
                 <div class="container">
                     <p style="text-align: center;font-size:smaller;">
-                        <a href="https://rcos.io/">A Rensselaer Center for Open-Source Project, 2014-2022.</a>
+                        <a href="https://rcos.io/">A Rensselaer Center for Open-Source Project, 2014-{{ 'now' | date: "%Y" }}.</a>
                     </p>
                 </div>
             </footer>


### PR DESCRIPTION
The date in the footer is currently listed as 2014-2022.  After this PR, the end date will be updated automatically on any build and we should never have to make an annual year bump PR again.