### PR TITLE
[Documentation:Developer] Vagrant port error for Apple Silicon Mac

### DIFF
--- a/_docs/developer/development_instructions/troubleshooting.md
+++ b/_docs/developer/development_instructions/troubleshooting.md
@@ -9,23 +9,40 @@ category: Developer > Development Instructions
 
 ## Forwarded Port Already in Use
 
-If you see an error similar to:
+* If you see an error similar to:
 
-```
-Vagrant cannot forward the specified ports on this VM, since they
-would collide with some other application that is already listening
-on these ports. The forwarded port to #### is already in use
-on the host machine.
-```
+  ```
+  Vagrant cannot forward the specified ports on this VM, since they
+  would collide with some other application that is already listening
+  on these ports. The forwarded port to #### is already in use
+  on the host machine.
+  ```
 
-This means that one or more of the ports requested by vagrant is already in
-use by another application running on your computer. You can choose to use
-an alternate port through an environment variable. The current variables are
-`VM_PORT_SITE`, `VM_PORT_WS`, `VM_PORT_DB`, `VM_PORT_SAML`, and `VM_PORT_SSH`.
+  This means that one or more of the ports requested by vagrant is already in
+  use by another application running on your computer.
 
-You can edit the Vagrantfile directly or create a `.env` file in the
-root of your project with the text (for example) `VM_PORT_SITE=1500`
-so that you don't have to add it to every `vagrant up` command.
+
+* This may happen if you attempt to create mutliple Submitty VMs --
+  perhaps unintentionally!  E.g., if you have multiple directories on
+  your computer each with a clone/copy of the Submitty repo.  It is
+  necessary to run `vagrant destroy` in each of these
+  directories/repositories to clean up unwanted VMs.
+
+  The following command can help locate misplaced repositories/VMs:
+
+  ```
+  vagrant global-status
+  ```
+
+
+* You can choose to override the default ports and use an alternate
+  port through an environment variable. The current variables are
+  `VM_PORT_SITE`, `VM_PORT_WS`, `VM_PORT_DB`, `VM_PORT_SAML`, and
+  `VM_PORT_SSH`.
+
+  You can edit the Vagrantfile directly or create a `.env` file in the
+  root of your project with the text (for example) `VM_PORT_SITE=1500`
+  so that you don't have to add it to every `vagrant up` command.
 
 
 ---

--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -439,7 +439,6 @@ with no explanation, then there are a couple of things that may be going wrong:
    This will delete all virtual machine settings. Then install
    the latest version of Virtual Box and vagrant from the links given in step 3 (using Ubuntu Software).
 
-
 * If it has been a while since your last `vagrant destroy` and
     `vagrant up` you may need to update/upgrade/reinstall the virtual
     box, vagrant, and the installed boxes on your

--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -430,19 +430,16 @@ with no explanation, then there are a couple of things that may be going wrong:
    This will delete all virtual machine settings. Then install
    the latest version of Virtual Box and vagrant from the links given in step 3 (using Ubuntu Software).
 
-* If you are on Apple Mac computer with [Apple Silicon (e.g., M1 or M2)](https://support.apple.com/en-us/HT211814),
-    and an error is thrown during `vagrant up` because the forwarded port is already in use
+* If you encounter an error during `vagrant up` because the forwarded port is already in use
     on the host machine, you may need to check if another VM is using that specified port. This may happen when 
     you have already installed a VM or the installation of vagrant failed and you didn't destroy vagrant.
-    You may use the following command to see the location of any other VM using that port then you may `vagrant destroy` : 
-    
-   ```
-   sudo lsof -i:<PORT> 
+    You may use the following command to see the location of any other VM then you may `vagrant destroy` : 
 
    ```
-    Where `<PORT>` is the specified forwarded port. 
+   vagrant global-status 
 
-
+   ```
+   
 * If it has been a while since your last `vagrant destroy` and
     `vagrant up` you may need to update/upgrade/reinstall the virtual
     box, vagrant, and the installed boxes on your

--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -430,6 +430,19 @@ with no explanation, then there are a couple of things that may be going wrong:
    This will delete all virtual machine settings. Then install
    the latest version of Virtual Box and vagrant from the links given in step 3 (using Ubuntu Software).
 
+* If you are on Apple Mac computer with [Apple Silicon (e.g., M1 or M2)](https://support.apple.com/en-us/HT211814),
+    and an error is thrown during `vagrant up` because the forwarded port is already in use
+    on the host machine, you may need to check if another VM is using that specified port. This may happen when 
+    you have already installed a VM or the installation of vagrant failed and you didn't destroy vagrant.
+    You may use the following command to see the location of any other VM using that port then you may `vagrant destroy` : 
+    
+   ```
+   sudo lsof -i:<PORT> 
+
+   ```
+    Where `<PORT>` is the specified forwarded port. 
+
+
 * If it has been a while since your last `vagrant destroy` and
     `vagrant up` you may need to update/upgrade/reinstall the virtual
     box, vagrant, and the installed boxes on your

--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -439,16 +439,7 @@ with no explanation, then there are a couple of things that may be going wrong:
    This will delete all virtual machine settings. Then install
    the latest version of Virtual Box and vagrant from the links given in step 3 (using Ubuntu Software).
 
-* If you encounter an error during `vagrant up` because the forwarded port is already in use
-    on the host machine, you may need to check if another VM is using that specified port. This may happen when 
-    you have already installed a VM or the installation of vagrant failed and you didn't destroy vagrant.
-    You may use the following command to see the location of any other VM then you may `vagrant destroy` : 
 
-   ```
-   vagrant global-status 
-
-   ```
-   
 * If it has been a while since your last `vagrant destroy` and
     `vagrant up` you may need to update/upgrade/reinstall the virtual
     box, vagrant, and the installed boxes on your


### PR DESCRIPTION
Added useful tip in the Installation troubleshooting for M1 or M2 users when they encounter the following error : 
"Vagrant cannot forward the specified ports on this VM, since they would collide with some other application that is already listening on these ports. The forwarded port to 1511 is already in use on the host machine."