### PR TITLE
[Documentation:Developer] Troubleshooting for pgAdmin

### DIFF
--- a/_docs/developer/getting_started/pgadmin.md
+++ b/_docs/developer/getting_started/pgadmin.md
@@ -25,7 +25,9 @@ redirect_from:
 * Once you have opened Navigate to the `Connection`sub-section.
   The following parameters should be changed:
 
-    * `Host name/address`: `localhost`.
+    * `Host name/address`: `localhost`. 
+
+      - If you get a connection timeout error, try `127.0.0.1` instead.
 
     * `Port`: `16442`
 


### PR DESCRIPTION
For some windows users, they need to set host name to "127.0.01" in order to connect to the Submitty database with pgAdmin.