### PR TITLE
[Documentation:Developer] Update PHPStan Baseline Command

### DIFF
--- a/_docs/developer/testing/linting_static_analysis.md
+++ b/_docs/developer/testing/linting_static_analysis.md
@@ -78,10 +78,10 @@ phpstan maintains a list of known errors in the [phpstan-baseline.neon](https://
 If you fix one of these errors, you would need to regenerate this file which can be done by doing:
 
 ```
-php -d memory_limit=8G vendor/bin/phpstan analyze app public/index.php socket/index.php --generate-baseline
+php vendor/bin/phpstan analyze app public/index.php socket/index.php --generate-baseline --memory-limit 2G
 ```
-The argument `-d memory_limit=8G` is necessary as otherwise phpstan will not have enough memory
-to generate a new baseline.
+The argument `--memory_limit 2G` is necessary when phpstan will otherwise not have enough memory
+to generate a new baseline. You can see how much memory phpstan has been using with the `-v` flag.
 
 ## JavaScript Linting
 

--- a/_docs/developer/testing/linting_static_analysis.md
+++ b/_docs/developer/testing/linting_static_analysis.md
@@ -78,8 +78,10 @@ phpstan maintains a list of known errors in the [phpstan-baseline.neon](https://
 If you fix one of these errors, you would need to regenerate this file which can be done by doing:
 
 ```
-php vendor/bin/phpstan analyze app public/index.php socket/index.php --generate-baseline
+php -d memory_limit=8G vendor/bin/phpstan analyze app public/index.php socket/index.php --generate-baseline
 ```
+The argument `-d memory_limit=8G` is necessary as otherwise phpstan will not have enough memory
+to generate a new baseline.
 
 ## JavaScript Linting
 


### PR DESCRIPTION
The PHP baseline command now suggests providing ``phpstan`` additional memory.

![image](https://github.com/Submitty/submitty.github.io/assets/51209504/a4c90369-bedb-4f59-89d9-73a097ba1bd2)

