### PR TITLE
[Documentation:System] info regarding stopping nginx

### DIFF
--- a/_docs/sysadmin/troubleshooting/system_debugging.md
+++ b/_docs/sysadmin/troubleshooting/system_debugging.md
@@ -81,3 +81,14 @@ redirect_from:
   When you replace your `.cert` file for apache, be sure to also
   replace the `.pem` file for nginx.  See also
   [v20.09.00 NGINX for Websocket Request](/sysadmin/installation/version_notes/v20.09.00).
+
+### Testing Websockets while NGINX is closed
+
+
+  * We want to make sure that the site remains 100% functional, minus the live updates, when Websockets are down
+    to test this you can stop NGINX in vagrant ssh to recreate this behavior by typing in:
+
+    ```
+    sudo systemctl stop nginx
+    ```
+    with nginx stopped you can test functions of the site without being connected to the websocket client.


### PR DESCRIPTION
updates the documentation regarding how to test submitty functions while the websocket connection is down.

originated from issue #9788, https://github.com/Submitty/Submitty/issues/9788