### PR TITLE
[Documentation:Developer] Database page redirects to pgAdmin page

### DIFF
--- a/_docs/developer/software_and_system_design/database_design.md
+++ b/_docs/developer/software_and_system_design/database_design.md
@@ -28,16 +28,7 @@ redirect_from:
    4. [DataGrip](https://www.jetbrains.com/datagrip/) ("Database IDE", can connect to most DB types)
 
 
-Note: When adding a new server to pgAdmin, change the following parameters in the
-server's `Connection` settings:
-
-* `Host name/address`: `localhost`
-* `Port`: `16442`
-* `Username`: `submitty_dbuser`
-* `Password`: `submitty_dbuser`
-
-You do not need to change the port or the maintenance database - the port should say `5432`
-and the maintenance database should say `postgres` by default.
+Note: To add the Submitty server to pgAdmin, follow the [pgAdmin setup instructions](/developer/pgadmin).
 
 
 

--- a/_docs/developer/software_and_system_design/database_design.md
+++ b/_docs/developer/software_and_system_design/database_design.md
@@ -28,7 +28,7 @@ redirect_from:
    4. [DataGrip](https://www.jetbrains.com/datagrip/) ("Database IDE", can connect to most DB types)
 
 
-Note: To add the Submitty server to pgAdmin, follow the [pgAdmin setup instructions](/developer/pgadmin).
+Note: To add the Submitty server to pgAdmin, follow the [pgAdmin setup instructions](/developer/getting_started/pgadmin).
 
 
 


### PR DESCRIPTION
Currently, both the Database design page and the pgadmin setup instructions pages have instructions on how to set up pgadmin. However, the pgadmin setup instructions page is more detailed and provides better instructions. I've changed the database design page to link to the pgadmin setup instructions page rather than providing its own less detailed instructions.