### PR TITLE
[Documentation:Developer] Fix WSL issue installing Cypress

### DIFF
--- a/_docs/developer/testing/cypress.md
+++ b/_docs/developer/testing/cypress.md
@@ -14,7 +14,7 @@ used to use Selenium, but has been rewritten in using Cypress.
 
 Make sure you have `node.js` version 10 or higher installed locally. You can check using the command: `node -v` 
 
-Make sure to install [`node.js`](https://www.nodejs.org/) on your desktop (inside Program Files) and not inside your local Submitty repository on your desktop. 
+If you have WSL and run into an error, make sure you installed [`node.js`](https://www.nodejs.org/) on your desktop (Program Files) and not inside your local Submitty repository.
 
 ```bash
 # from the site directory

--- a/_docs/developer/testing/cypress.md
+++ b/_docs/developer/testing/cypress.md
@@ -11,10 +11,7 @@ directly, but rather focuses on user navigation through the website. It
 used to use Selenium, but has been rewritten in using Cypress.
 
 ## Installation 
-
-Make sure you have `node.js` version 10 or higher installed locally. You can check using the command: `node -v` 
-
-If you have WSL and run into an error, make sure you installed [`node.js`](https://www.nodejs.org/) on your desktop (Program Files) and not inside your local Submitty repository.
+Make sure you have [`node.js`](https://www.nodejs.org/)  version 10 or higher installed locally. You can check using the command: `node -v` 
 
 ```bash
 # from the site directory
@@ -22,6 +19,8 @@ npm install
 ```
 
 If you are on Linux, view [this page](https://docs.cypress.io/guides/getting-started/installing-cypress.html#Linux) to see what dependencies you may need to install additionally for Cypress.
+
+If you are on WSL and run into an error, make sure you installed `node.js` on your desktop (Program Files) and not inside your local Submitty repository.
 
 ## Cypress Test Runner
 

--- a/_docs/developer/testing/cypress.md
+++ b/_docs/developer/testing/cypress.md
@@ -14,6 +14,8 @@ used to use Selenium, but has been rewritten in using Cypress.
 
 Make sure you have `node.js` version 10 or higher installed locally. You can check using the command: `node -v` 
 
+Make sure to install [`node.js`](https://www.nodejs.org/) on your desktop (inside Program Files) and not inside your local Submitty repository on your desktop. 
+
 ```bash
 # from the site directory
 npm install


### PR DESCRIPTION
Changes: Added "If you are on WSL and run into an error, make sure you installed `node.js` on your desktop (Program Files) and not inside your local Submitty repository." in cypress.md (https://submitty.org/developer/testing/cypress)

WHY: I ran into a issue while installing cypress (I installed node.js in the wrong file) and this is to help others who might run into the same issue.

<img width="859" alt="image" src="https://github.com/Submitty/submitty.github.io/assets/117528498/bd1ac264-f5cd-4235-9684-04ffc5300db2">
