### PR TITLE
[Documentation:InstructorUI] fix drop lowest description 

### DIFF
--- a/_docs/instructor/course_settings/rainbow_grades/manual_setup.md
+++ b/_docs/instructor/course_settings/rainbow_grades/manual_setup.md
@@ -184,19 +184,23 @@ redirect_from:
 Although it is not yet implemented in web-GUI, RainbowGrades support drop lowest grade.
 Directly edit the customization.json file
 Here is a example usage, removing one lowest gradeable from given type
-``` 
+  ```json
 {
-   “count”: 8,
-   “percent”: 0.12,
-   “type”: “quiz”,
-   “remove_lowest”: 1,
-   “ids”: [
-      {
-      “max”: 10.0,
-      “id”: “quiz01",
-      “percent”: 0.125,
-      “released”: true
-      },
-...
+  "count": 8,
+  "percent": 0.12,
+  "type": "quiz",
+  "remove_lowest": 1,
+  "ids": [
+    {
+      "max": 10.0,
+      "id": "quiz01",
+      "percent": 0.125,
+      "released": true
+    }
+     ]
+}
+  ```
+
+
 
 

--- a/_docs/instructor/course_settings/rainbow_grades/manual_setup.md
+++ b/_docs/instructor/course_settings/rainbow_grades/manual_setup.md
@@ -179,3 +179,24 @@ redirect_from:
 
 [SAMPLE_Makefile]: https://github.com/Submitty/RainbowGrades/blob/main/SAMPLE_Makefile
 [SAMPLE_customization.json]: https://github.com/Submitty/RainbowGrades/blob/main/SAMPLE_customization.json
+
+[Drop lowest function]
+Although it is not yet implemented in web-GUI, RainbowGrades support drop lowest grade.
+Directly edit the customization.json file
+Here is a example usage, removing one lowest gradeable from given type
+``` 
+{
+   “count”: 8,
+   “percent”: 0.12,
+   “type”: “quiz”,
+   “remove_lowest”: 1,
+   “ids”: [
+      {
+      “max”: 10.0,
+      “id”: “quiz01",
+      “percent”: 0.125,
+      “released”: true
+      },
+...
+
+


### PR DESCRIPTION
![Screen Shot 2023-11-11 at 11 34 43 PM](https://github.com/Submitty/submitty.github.io/assets/123261952/788a8d0f-b7ec-492a-9957-00af57c4a113)


It was missing a delimiter, now it does