### PR TITLE
[Documentation:Developer] Removed travis docs

### DIFF
--- a/_docs/developer/software_and_system_design/coding_style_guide/python.md
+++ b/_docs/developer/software_and_system_design/coding_style_guide/python.md
@@ -8,11 +8,9 @@ redirect_from:
 __Minimum Version__: 3.8
 
 For Python, we use [flake8](http://flake8.pycqa.org/en/latest/) to check Python code such that it follows things laid out in
-[PEP-8](https://www.python.org/dev/peps/pep-0008/), [PEP-257](https://www.python.org/dev/peps/pep-0257/), etc. The code is
-linted as part of our automated Travis-CI testsuite to ensure compliance. To locally lint the code, you will need to
-install three modules:
+[PEP-8](https://www.python.org/dev/peps/pep-0008/), [PEP-257](https://www.python.org/dev/peps/pep-0257/), etc. 
+To locally lint the code, you will need to install three modules:
 
     pip3 install flake8 flake8-bugbear
 
 and then you can just run `flake8` at the root to check all files or pass it an individual file to check just that.
-To see all files that are currently checked as part of Travis-CI, please look at the `.flake8` config file.

--- a/_docs/developer/testing/linting_static_analysis.md
+++ b/_docs/developer/testing/linting_static_analysis.md
@@ -23,9 +23,6 @@ level of Submitty source tree:
 python3 -m flake8
 ```
 
-_NOTE: Our Travis CI testing currently [excludes a number of legacy source code files](https://github.com/Submitty/Submitty/blob/master/.flake8).
-from Python linting, though there is effort to bring more and more of them under flake8._
-
 Optionally, you can pass in a specific file or directory to only lint that file or directory, e.g.:
 
 ```bash


### PR DESCRIPTION
We no longer use Travis CI, so the documentation has been mostly updated to no longer show our uses in Travis CI