### PR TITLE
[Documentation:System] Clarify opening and closing symbols need to match in Markdown

### DIFF
--- a/_docs/student/communication/markdown.md
+++ b/_docs/student/communication/markdown.md
@@ -42,15 +42,18 @@ using markdown.
 
 
 *  **Italics**  
-    Adding `_` (one underscore) or `*` (one asterisk) before and after text will _italicize_ that text.
+    Adding `_` (one underscore) or `*` (one asterisk) before and after text will _italicize_ that text. Opening
+    and closing symbols need to match.
 
 
 *  **Bold**  
-    Adding `__` (two underscores) `**` (two asterisks) before and after text will make that text __bold__.
+    Adding `__` (two underscores) `**` (two asterisks) before and after text will make that text __bold__. Opening
+    and closing symbols need to match.
 
 
 *  **Bold and Italics**  
     Adding `___` (three underscores) `***` (three asterisks) before and after text will make that text ___bold and italic___.
+    Opening and closing symbols need to match.
 
 
 *  **Inline Code**  


### PR DESCRIPTION
Markdown allows using two different sets of symbols for the same action (bold, italic, etc.) but needs the starting symbol and the closing symbol to be the same symbol, so no mix-and-matching is allowed.