### PR TITLE
[Documentation:System] Clarified Ubuntu live server unsupported

### DIFF
--- a/_docs/sysadmin/installation/server_os.md
+++ b/_docs/sysadmin/installation/server_os.md
@@ -30,6 +30,8 @@ next academic year from when we added support of the new LTS version.
 For the other distros, we will attempt to support the latest version
 before dropping support, but may drop support at anytime.
 
+Please do not use Ubuntu 2X.04 “Live” version, only the traditional version is supported.
+
 ### Partitioning the disk
 
 Assuming this is a standalone machine with no other information on 


### PR DESCRIPTION
There is no clarification for sysadmins to not use the "Live" server version of Ubuntu in the "ServerOS" section of the documentation. It is only mentioned at the bottom of the installation instructions in the "Overview" section. This is bad because it could lead a sysadmin to complete the most of the installation process, only to realize at the end that their OS version is not supported. This pull request addresses that issue by inserting a clarification in the ServerOS section.