### PR TITLE
[Documentation:Developer] Other Names for BIOS Virtualization 

### DIFF
--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -93,7 +93,7 @@ If you using an Intel-based Mac, you will follow the instructions below._
 
    7. Enter your **BIOS** (generally by pressing Del, F12, or other keys while booting). If you are not able to find the key combo needed to enter your BIOS, refer to [this guide](https://www.tomshardware.com/reviews/bios-keys-to-access-your-firmware,5732.html).
 
-   8. Locate **Virtualization**, and enable it. (Some motherboards may call it SVM, AMD-V, VT-x/Vanderpool) (Note: If you cannot find the option to enable virtualization, [search Google](http://tinyurl.com/enable-virtualization) for a tutorial on enabling it with your motherboard.) 
+   8. Locate **Virtualization**, and enable it. (Note: Some motherboards may call it SVM, AMD-V, VT-x/Vanderpool. If you cannot find the option to enable virtualization, [search Google](http://tinyurl.com/enable-virtualization) for a tutorial on enabling it with your motherboard.) 
 
    9. Reboot your computer.
 


### PR DESCRIPTION
Adds to Getting Started -> VM install using vagrant -> Submitty Developer Installation -> 1. Enable Virtualization. When setting up the VM for the first time I ran into some unnecessary confusion because my laptops BIOS called the Virtualization SVM, and it turns out it is common for it to be called other things, so I specified that and some other commonly used BIOS setting names for Virtualization.