### PR TITLE
[DevDependency] Downgrade Ruby to 3.0 in Workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Get Ruby version
       id: rubyversion
-      run: echo "::set-output name=version::2.7"
+      run: echo "::set-output name=version::3.2"
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Get Ruby version
       id: rubyversion
-      run: echo "::set-output name=version::$(curl https://raw.githubusercontent.com/github/pages-gem/master/.ruby-version)"
+      run: echo "::set-output name=version::3.0"
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Get Ruby version
       id: rubyversion
-      run: echo "::set-output name=version::3.0"
+      run: echo "::set-output name=version::2.7"
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/_docs/sysadmin/configuration/registration_feed.md
+++ b/_docs/sysadmin/configuration/registration_feed.md
@@ -153,7 +153,7 @@ This defines the constant `CSV_FILE` and sets its value to `/path/to/datafile.cs
 _Do not change the constant_.
 Only change the constant's value.
 
-We would need to change the value to reflect where the student data CSV is located (did you [note this](/sysadmin/configuration/registration_feed#4-before-installing-auto-feed-script) back in chapter 3?).
+We would need to change the value to reflect where the student data CSV is located (did you [note this](/sysadmin/configuration/registration_feed#3-before-installing-auto-feed-script) back in chapter 3?).
 For example, if your data warehouse delivers the feed CSV to `/users/datawarehouse/enrollment.csv` -- then change the line to read:
 ```php
 define('CSV_FILE', '/users/datawarehouse/enrollment.csv');

--- a/_docs/sysadmin/configuration/registration_feed.md
+++ b/_docs/sysadmin/configuration/registration_feed.md
@@ -153,7 +153,7 @@ This defines the constant `CSV_FILE` and sets its value to `/path/to/datafile.cs
 _Do not change the constant_.
 Only change the constant's value.
 
-We would need to change the value to reflect where the student data CSV is located (did you [note this](/sysadmin/configuration/registration_feed#3-before-installing-auto-feed-script) back in chapter 3?).
+We would need to change the value to reflect where the student data CSV is located (did you [note this](/sysadmin/configuration/registration_feed#4-before-installing-auto-feed-script) back in chapter 3?).
 For example, if your data warehouse delivers the feed CSV to `/users/datawarehouse/enrollment.csv` -- then change the line to read:
 ```php
 define('CSV_FILE', '/users/datawarehouse/enrollment.csv');


### PR DESCRIPTION
Ruby tests are currently not making it pass Build Site on main. By downgrading the version, Ruby tests will successfully get past Build Site.

Ruby tests still won't pass on main until PR #590 is also merged.