### PR TITLE
[Documentation:System] Term creation instructions

### DIFF
--- a/_docs/sysadmin/configuration/term_creation.md
+++ b/_docs/sysadmin/configuration/term_creation.md
@@ -1,0 +1,32 @@
+---
+title: Term Creation
+category: System Administrator > Configuration & Administration
+redirect_from:
+  - /sysadmin/course_creation
+---
+
+
+### Creating a term
+To create a term, you should use the script 
+```
+/usr/local/submitty/sbin/create_term.sh
+```
+Follow these usage guidelines: 
+```
+Usage: create_term.sh  [-a|--amend] <term>  '<name of term>'  <start date>  <end date>
+```
+
+The term should be an abbreviated semester name like:
+```
+s24
+```
+While name of term would be a more descriptive name like "Spring 2024".
+
+The start and end date must be formatted in mm/dd/yyyy format.
+
+Use -a or --amend to amend an existing term.
+An example valid usage of this command would be:
+
+```
+create_term.sh s24 'Spring 2024' 01/09/2024 05/01/2024
+```

--- a/navtreedata.js
+++ b/navtreedata.js
@@ -164,6 +164,7 @@ var NAVTREE =
                 [ "System Customization", "/sysadmin/installation/system_customization", null ],
             ] ],
             [ "Configuration & Administration", "/sysadmin/configuration/course_creation", [
+                [ "Term Creation", "/sysadmin/configuration/term_creation", null ],
                 [ "Course Creation", "/sysadmin/configuration/course_creation", null ],
                 [ "Setting up Version Control", "/sysadmin/configuration/version_control", null ],
                 [ "SAML Authentication", "/sysadmin/configuration/saml_authentication", null ],


### PR DESCRIPTION
I created a new file and added instructions for usage of the create_term.sh script to create a script. I added it to the top of the configuration section as that is likely the first thing that the sysadmin should be doing.