### PR TITLE
[Bugfix:System] Test server requires json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem 'wdm', '>= 0.1.1' if Gem.win_platform?
 gem "webrick", "~> 1.8"
 
 gem 'html-proofer', "~> 3.19.4"
+
+gem 'json'


### PR DESCRIPTION
On my machine, the test server required json to be included in the gemfile in order to be run. I altered the Gemfile to include it. I would like people to try to replicate the issue to make sure it wasn't just a problem with me.