### PR TITLE
[Documentation:InstructorUI] Upload Gradeable missing navbar

### DIFF
--- a/navtreedata.js
+++ b/navtreedata.js
@@ -111,6 +111,7 @@ var NAVTREE =
                 [ "Team Assignments", "/instructor/assignment_preparation/team_assignments", null ],
                 [ "Bulk PDF Upload", "/instructor/assignment_preparation/bulk_pdf_upload", null ],
                 [ "Personalized Exam", "/instructor/assignment_preparation/personalized_exams", null ],
+                [ "Upload Gradeable from JSON", "/instructor/assignment_preparation/upload_gradeable", null ],
             ] ],
             [ "Assignment Configuration", "/instructor/assignment_configuration/configuration_path", [
                 [ "Configuration Path","/instructor/assignment_configuration/configuration_path", null],


### PR DESCRIPTION
The upload gradeable via json is a page under instructor/assignment_preparation but doesn't show up in the navbar  

it now looks like:
![image](https://github.com/Submitty/submitty.github.io/assets/12129065/06ace259-7173-4216-8034-a71b25dd2afd)
