### PR TITLE
[Documentation:System] Added documentation for configuring custom websocket port in NGINX

### DIFF
--- a/_docs/sysadmin/installation/index.md
+++ b/_docs/sysadmin/installation/index.md
@@ -196,6 +196,38 @@ You can use these [instructions](/sysadmin/installation/ansible).
    cp submitty.cer submitty.pem
    cat chain.cer >> submitty.pem
    ```
+       #### Configure Websocket Port
+
+    Submitty allows you to configure the websocket server to use a custom port. To do this:
+    
+    Open the Submitty configuration file:
+    
+       bash
+       /usr/local/submitty/config/submitty.json```
+    
+     Add or modify the websocket_port field, for example:
+       
+       "websocket_port": 9001
+       ```
+     The websocket server will default to port 8443 if this value is not set.
+       Update the proxy_pass directive in your NGINX configuration 
+       ```(/etc/nginx/sites-available/submitty.conf)``` to match the new port:
+   ```
+   location /ws {
+    proxy_pass http://127.0.0.1:9001; # Updated port here
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+    }
+    ```
+    
+    Restart NGINX for the changes to take effect:
+    
+       ```
+       sudo systemctl restart nginx
+       ```
+
 
 7. We recommend that you should leave the PostgreSQL setup unless you know what
    you're doing. If you are running PostgreSQL on the same server as Submitty,


### PR DESCRIPTION
### Summary:
- Added a new section under NGINX configuration to explain how to set up a custom websocket port.
- Included steps to modify the `submitty.json` file and update the `proxy_pass` directive in the NGINX configuration.
- Clarified default behavior if the `websocket_port` field is not set.

### Why this change is needed:
- Previously, the documentation lacked details for configuring custom websocket ports after #6814 was merged. 
- An issue was created on [here](https://github.com/Submitty/Submitty/issues/6813). Fixes #6813
- Helps users avoid conflicts when running multiple instances or using different environments.

### Changes made:
- Added a new "Configure Websocket Port" section to the NGINX setup documentation.
- Provided clear step-by-step instructions and examples.

### Testing:
- Documentation changes only, no code changes. 
- Verified formatting and clarity.
