### PR TITLE
[Documentation:Developer] set git credentials working with forks

### DIFF
--- a/_docs/developer/getting_started/commit_to_PR_from_fork.md
+++ b/_docs/developer/getting_started/commit_to_PR_from_fork.md
@@ -65,6 +65,13 @@ The instructions below are for command line use of git.
     and review the PR and make code edits and new commits to your
     local branch as needed.
 
+    Note: make sure your git credentials are set before pulling or pushing to a forked 
+    branch. You can do this with the following commands. Use the --global flag if you 
+    want to set this outside of just Submitty.
+    '''
+    git config user.name "Your Name"
+    git config user.email "Your Email"
+    '''
 
 
 5.  In order to push the changes to the contributor's fork (and the PR

--- a/_docs/developer/getting_started/commit_to_PR_from_fork.md
+++ b/_docs/developer/getting_started/commit_to_PR_from_fork.md
@@ -40,7 +40,15 @@ The instructions below are for command line use of git.
     ```
 
     Additionally, find the name of the fork on the fork's page on Github.  
-    The `fork_name` may simply be `Submitty`, or the author may have chosen to another name.
+    The `fork_name` may simply be `Submitty`, or the author may have chosen another name.
+
+    Note: make sure your git credentials are set before pulling or pushing to a forked 
+    repo. You can do this with the following commands. Use the `--global` flag if you 
+    want to set this outside of just Submitty.
+    ```
+    git config user.name "Your Name"
+    git config user.email "Your Email"
+    ```
     
 
 3.  Next, make a local branch on your computer in your working repository
@@ -65,13 +73,6 @@ The instructions below are for command line use of git.
     and review the PR and make code edits and new commits to your
     local branch as needed.
 
-    Note: make sure your git credentials are set before pulling or pushing to a forked 
-    branch. You can do this with the following commands. Use the --global flag if you 
-    want to set this outside of just Submitty.
-    '''
-    git config user.name "Your Name"
-    git config user.email "Your Email"
-    '''
 
 
 5.  In order to push the changes to the contributor's fork (and the PR


### PR DESCRIPTION
**Summary:**
Added a small warning in the "Commit to PR from fork" page that tells developers to ensure that their git credentials are set before pulling and pushing from forks. If credentials are not set, then some commands will fail. This change would help newer developers who might not be proficient with git.

**Testing**
- Verified that changes appeared on the page
- Format looks good