### PR TITLE
[Documentation:Developer] update VirtualBox link

### DIFF
--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -123,7 +123,8 @@ M-Series ARM MacOS machines.*
       * [Git](https://git-scm.com/downloads)  
       * [Vagrant](https://www.vagrantup.com)  
       * *M-SERIES ARM MacOS:* [QEMU](https://www.qemu.org)  
-      * *EVERYONE ELSE:* [VirtualBox](https://www.virtualbox.org/wiki/Download_Old_Builds_6_1)  
+      * *EVERYONE ELSE:* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+          * Ensure VirtualBox version is compatible with Vagrant.
    
    
    * **MacOS**  


### PR DESCRIPTION
The developer instructions for VM install include a link to VirtualBox version 6.1, but 7.1 is now compatible with Vagrant. 6.1 is no longer supported and Windows security updates may be causing issues.

### What is the current documentation?
The link leads to VirtualBox 6.1
![image](https://github.com/user-attachments/assets/a84d0467-6557-43b1-b235-edc379dd7f99)


### What is the new documentation?
The link leads to the latest version of VirtualBox.
![image](https://github.com/user-attachments/assets/63e5231f-8c5c-420f-a130-2ead7a34a5a3)
