### PR TITLE
[Bugfix:InstructorUI] Valid Gradeable Syllabus Bucket Examples

### DIFF
--- a/_docs/instructor/assignment_preparation/index.md
+++ b/_docs/instructor/assignment_preparation/index.md
@@ -278,7 +278,7 @@ Below is the list of parameters downloaded. VCS and Team Gradeable are only down
   "grade_inquiry_per_component_allowed": false,
   "ta_grading": false,
   "discussion_thread_id": "thread_id",
-  "syllabus_bucket": "Homework",
+  "syllabus_bucket": "homework",
   "autograding_config_path": "path/to/config",
   "dates": {
     "ta_view_start_date": "2024-1-10 23:59:59.00",

--- a/_docs/instructor/assignment_preparation/upload_gradeable.md
+++ b/_docs/instructor/assignment_preparation/upload_gradeable.md
@@ -88,7 +88,7 @@ Four digit year, one or two digit month, two digit day, two digit hour, minute, 
 #### Other
 * ta_grading -- If the TA will grade any/all of the assignments (Default false)
 * discussion_thread_id -- The thread ID if using forums (Default none)
-* syllabus_bucket -- (Default "Homework")
+* syllabus_bucket -- (Default "homework")
 #### All variables
 ```json
 {
@@ -110,7 +110,7 @@ Four digit year, one or two digit month, two digit day, two digit hour, minute, 
   "grade_inquiry_per_component_allowed": false,
   "ta_grading": false,
   "discussion_thread_id": "thread_id",
-  "syllabus_bucket": "Homework",
+  "syllabus_bucket": "homework",
   "dates": {
     "ta_view_start_date": "2024-1-10 23:59:59",
     "submission_open_date": "2024-1-10 23:59:59",
@@ -135,7 +135,7 @@ Four digit year, one or two digit month, two digit day, two digit hour, minute, 
   "id": "hw-bulk-upload",
   "type": "Electronic File",
   "bulk_upload": true,
-  "syllabus_bucket": "Homework"
+  "syllabus_bucket": "homework"
 }
 ```
 #### Sample Checkpoints Template
@@ -144,7 +144,7 @@ Four digit year, one or two digit month, two digit day, two digit hour, minute, 
   "title": "Checkpoints Gradeable",
   "id": "hw-checkpoints",
   "type": "Checkpoints",
-  "syllabus_bucket": "Homework"
+  "syllabus_bucket": "homework"
 }
 ```
 #### Sample VCS Template
@@ -153,7 +153,7 @@ Four digit year, one or two digit month, two digit day, two digit hour, minute, 
   "title": "VCS Gradeable",
   "id": "hw-vcs",
   "type": "Electronic File",
-  "syllabus_bucket": "Homework",
+  "syllabus_bucket": "homework",
   "vcs": {
     "repository_type": "submitty-hosted",
     "vcs_path": "http://localhost:1511/path/to/repository",

--- a/_docs/instructor/course_settings/rainbow_grades/customization_basics.md
+++ b/_docs/instructor/course_settings/rainbow_grades/customization_basics.md
@@ -24,7 +24,7 @@ The display field specifies what will be shown in the output HTML and individual
 It can contain the following:
 
 * ``"instructor_notes"``: Shows notes for early warnings, plagiarism, etc. only to the instructor
-* ``"grade_summary"``: Shows the overall score and score for each syllabus bucket (e.g. Homework)
+* ``"grade_summary"``: Shows the overall score and score for each syllabus bucket (e.g. homework)
 * ``"grade_details"``: Shows the score for each gradeable
 * ``"section"``: Show the students' registration section.
 * ``"messages"``: Show a text message at the top of the page.


### PR DESCRIPTION
Small updates related to gradable preparation examples. The current examples display `Homework` as a viable syllabus bucket option, but the backend expects `homework`. This is associated with the upcoming updates in https://github.com/Submitty/Submitty/pull/11544.