### PR TITLE
[Documentation:System] Improve Windows installation details

### DIFF
--- a/_docs/developer/getting_started/vm_install_using_vagrant.md
+++ b/_docs/developer/getting_started/vm_install_using_vagrant.md
@@ -121,7 +121,7 @@ M-Series ARM MacOS machines.*
    * You will need:     
       * [Ruby](https://www.ruby-lang.org/en/downloads)  
       * [Git](https://git-scm.com/downloads)  
-      * [Vagrant](https://www.vagrantup.com)  
+      * [Vagrant](https://developer.hashicorp.com/vagrant/install)
       * *M-SERIES ARM MacOS:* [QEMU](https://www.qemu.org)  
       * *EVERYONE ELSE:* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
           * Ensure VirtualBox version is compatible with Vagrant.
@@ -146,8 +146,8 @@ M-Series ARM MacOS machines.*
       ```
 
    * **Windows**  
-      *You can just go to the respective sites and download the necessary binaries.*
-
+      Download the latest Vagrant AMD64 binary for windows.
+      *As of Vagrant version 2.4.7, Virtualbox 7.1.10 is compatible.*
 
    * **Ubuntu/Debian**
 


### PR DESCRIPTION
I was previously unable to vagrant up from box because I thoughtlessly downloaded the I686 version from vagrant, thinking that AMD64 was incompatible with my Intel CPU (silly, I know). This PR gives more detailed instructions for what exactly to download for Windows users. 