### PR TITLE
[Documentation:Developer] Improve php unit test instructions

### DIFF
--- a/_docs/developer/testing/install_php.md
+++ b/_docs/developer/testing/install_php.md
@@ -23,6 +23,10 @@ If you are missing extensions you can install them with `PECL` which will be
 installed automatically with PHP, but you should have everything required by 
 default.
 
+### Windows
+
+Download [php 8.1](https://windows.php.net/download/) as a zip file under the thread safe category. Then extract the contents of the zip to a folder, and add the path to that folder to your path system variable. It's suggested that one extracts the contents of the zip to a folder called `php`, which can be put at `C:\php` for simplicity. You can then add `C:\php` to your path system environment variable.
+
 ------------- 
 
 Verify you have PHP installed correctly, submitty requires a version greater than 7.0

--- a/_docs/developer/testing/install_php.md
+++ b/_docs/developer/testing/install_php.md
@@ -8,7 +8,7 @@ you will need to have PHP installed on your host machine first.
 
 ### Linux & WSL:
 
-*If you're distro cannot find the correct package or installs the wrong version you may have to specify php7.0 in each package name*
+*If you're distro cannot find the correct package or installs the wrong version you may have to specify php8.1 in each package name*
 
 ```bash
 sudo apt-get update

--- a/_docs/developer/testing/linting_static_analysis.md
+++ b/_docs/developer/testing/linting_static_analysis.md
@@ -58,7 +58,7 @@ The following instructions were tested for Windows:
 
 1. First, you will need PHP installed on your host system first. See [Installing PHP](/developer/testing/install_php)*
 
-2. Next, you will need [Composer](https://getcomposer.org/doc/00-intro.md) installed on your host system as well.
+2. Next, you will need [Composer](https://getcomposer.org/download/) installed on your host system as well.
 	During this install, you will need to change settings in a php.ini file. Change the settings the prompt recommends.
 
 3. Run ``composer global require slevomat/coding-standard`` and ``composer global require "squizlabs/php_codesniffer=*"`` inside your terminal.

--- a/_docs/developer/testing/php_unit_tests.md
+++ b/_docs/developer/testing/php_unit_tests.md
@@ -6,21 +6,19 @@ category: Developer > Development Instructions > Continuous Integration Testing
 To validate the unit behavior of the site code, we utilize 
 [phpunit](https://phpunit.readthedocs.io/en/latest). 
 
-### Dependencies
-
-Before running PHP Unit Tests, you must install the required dependencies:
-
-1. Install [Composer](https://getcomposer.org/download/) through the command-line installation copy-paste.
-2. `cd` to `/usr/local/submitty/GIT_CHECKOUT/Submitty/site/`.
-3. run  `composer update`
-
-*If tests are failing on main, you may need to run `apt install php-sqlite3`, especially if you haven't vagrant upped from scratch in a while.*
+*If tests are failing for you even on main, you may need to run `apt install php-sqlite3`, especially if you haven't vagrant upped from scratch in a while.*
 
 ### Running PHP Unit Tests
 
 *If you are running on WSL and are seeing errors, remove `php` from the following commands.*
 
-To run the PHP unit test suite locally, `cd` to `/usr/local/submitty/GIT_CHECKOUT/Submitty/site/` and type:
+To run the PHP unit test suite in VM use the alias
+
+```
+submitty_test php-unit
+```
+
+or
 
 ```
 sudo -u submitty_php php vendor/bin/phpunit
@@ -28,21 +26,21 @@ sudo -u submitty_php php vendor/bin/phpunit
 
 To run just an individual class or test, you can use the `--filter` flag on PHPUnit.
 For example, to run the function `testInvalidProperty` would be
-`php vendor/bin/phpunit --filter testInvalidProperty` and running all
+`sudo -u submitty_php php vendor/bin/phpunit --filter testInvalidProperty` and running all
 of `AccessControlTester` would be
 `php vendor/bin/phpunit--filter AccessControlTester`. Be aware, filter
 can match against partial strings, so if you have two tests `testFoo` and `testFooBar`,
 running `--filter testFoo` will run them both. Alternatively, you can also directly run
 `phpunit` against a specific class by passing the path to the test class directly to
 `phpunit`, for example
-`php vendor/bin/phpunit tests/app/authentication/DatabaseAuthenticationTester.php` will run
+`sudo -u submitty_php php vendor/bin/phpunit tests/app/authentication/DatabaseAuthenticationTester.php` will run
 only the test methods in `DatabaseAuthenticationTester.php`.
 
 The two concepts above can be combined to run a specific test function in a specific
 class by doing:
 
 ```bash
-vendor/bin/phpunit --filter testFunction tests/app/path/to/TestClass.php
+sudo -u submitty_php php vendor/bin/phpunit --filter testFunction tests/app/path/to/TestClass.php
 ```
 
 You can pass in the `--debug` flag when using PHPUnit to see PHP output, this can be

--- a/_docs/developer/testing/php_unit_tests.md
+++ b/_docs/developer/testing/php_unit_tests.md
@@ -13,12 +13,27 @@ Before running PHP Unit Tests, you must install the required dependencies. You m
 ##### Inside the Vagrant VM
 
 1. Install [Composer](https://getcomposer.org/download/) through the command-line installation copy-paste.
-2. `cd` to `/usr/local/submitty/GIT_CHECKOUT/Submitty/site/`
+2. `cd` to `/usr/local/submitty/GIT_CHECKOUT/Submitty/site/`.
 3. run  `composer update`
 
 *Please be aware that many unit tests will not work inside the VM. It is suggested that you run tests individually.*
 
-##### On Your Local Machine
+##### On Mac
+
+1. Install [Composer](https://getcomposer.org/download/) using brew.
+2. `cd` to your `Submitty/site/` folder.
+3. run `composer install`
+
+##### On Windows (Not Suggested)
+
+1. Navigate to your php folder, and open the php configuration settings file.
+2. Ctrl-F and uncomment the line labelled `extension=fileinfo` (remove the semi-colon). Do the same for the line labelled `extension=sodium`.
+3. Install [Composer](https://getcomposer.org/download/), click the link labelled Composer-Setup.exe.
+4. Restart your terminal.
+5. `cd` to your `Submitty/site/` folder.
+6. Run `composer update`. If you are getting timeout errors, try using a VPN.
+
+*This is not a good way to run unit tests because many file paths will be broken. Like with the vagrant VM, it is suggested that you run tests individually.*
 
 ### Running PHP Unit Tests
 

--- a/_docs/developer/testing/php_unit_tests.md
+++ b/_docs/developer/testing/php_unit_tests.md
@@ -8,32 +8,13 @@ To validate the unit behavior of the site code, we utilize
 
 ### Dependencies
 
-Before running PHP Unit Tests, you must install the required dependencies. You may either run your tests locally or inside the VM:
-
-##### Inside the Vagrant VM
+Before running PHP Unit Tests, you must install the required dependencies:
 
 1. Install [Composer](https://getcomposer.org/download/) through the command-line installation copy-paste.
 2. `cd` to `/usr/local/submitty/GIT_CHECKOUT/Submitty/site/`.
 3. run  `composer update`
 
-*Please be aware that many unit tests will not work inside the VM. It is suggested that you run tests individually.*
-
-##### On Mac
-
-1. Install [Composer](https://getcomposer.org/download/) using brew.
-2. `cd` to your `Submitty/site/` folder.
-3. run `composer install`
-
-##### On Windows (Not Suggested)
-
-1. Navigate to your php folder, and open the php configuration settings file.
-2. Ctrl-F and uncomment the line labelled `extension=fileinfo` (remove the semi-colon). Do the same for the line labelled `extension=sodium`.
-3. Install [Composer](https://getcomposer.org/download/), click the link labelled Composer-Setup.exe.
-4. Restart your terminal.
-5. `cd` to your `Submitty/site/` folder.
-6. Run `composer update`. If you are getting timeout errors, try using a VPN.
-
-*This is not a good way to run unit tests because many file paths will be broken. Like with the vagrant VM, it is suggested that you run tests individually.*
+*If tests are failing on main, you may need to run `apt install php-sqlite3`, especially if you haven't vagrant upped from scratch in a while.*
 
 ### Running PHP Unit Tests
 
@@ -42,7 +23,7 @@ Before running PHP Unit Tests, you must install the required dependencies. You m
 To run the PHP unit test suite locally, `cd` to `/usr/local/submitty/GIT_CHECKOUT/Submitty/site/` and type:
 
 ```
-php vendor/bin/phpunit
+sudo -u submitty_php php vendor/bin/phpunit
 ```
 
 To run just an individual class or test, you can use the `--filter` flag on PHPUnit.

--- a/_docs/developer/testing/php_unit_tests.md
+++ b/_docs/developer/testing/php_unit_tests.md
@@ -6,14 +6,25 @@ category: Developer > Development Instructions > Continuous Integration Testing
 To validate the unit behavior of the site code, we utilize 
 [phpunit](https://phpunit.readthedocs.io/en/latest). 
 
+### Dependencies
+
+Before running PHP Unit Tests, you must install the required dependencies. You may either run your tests locally or inside the VM:
+
+##### Inside the Vagrant VM
+
+1. Install [Composer](https://getcomposer.org/download/) through the command-line installation copy-paste.
+2. `cd` to `/usr/local/submitty/GIT_CHECKOUT/Submitty/site/`
+3. run  `composer update`
+
+*Please be aware that many unit tests will not work inside the VM. It is suggested that you run tests individually.*
+
+##### On Your Local Machine
 
 ### Running PHP Unit Tests
 
-*You will need PHP installed on your host system first, see [Installing PHP](/developer/testing/install_php)*
+*If you are running on WSL and are seeing errors, remove `php` from the following commands.*
 
-To run the PHP unit test suite locally, `cd` to the `Submitty/site` directory and type:
-
-If you are running on WSL and are seeing errors, remove "`php`" from the following commands.
+To run the PHP unit test suite locally, `cd` to `/usr/local/submitty/GIT_CHECKOUT/Submitty/site/` and type:
 
 ```
 php vendor/bin/phpunit

--- a/_docs/developer/testing/php_unit_tests.md
+++ b/_docs/developer/testing/php_unit_tests.md
@@ -6,7 +6,6 @@ category: Developer > Development Instructions > Continuous Integration Testing
 To validate the unit behavior of the site code, we utilize 
 [phpunit](https://phpunit.readthedocs.io/en/latest). 
 
-*If tests are failing for you even on main, you may need to run `apt install php-sqlite3`, especially if you haven't vagrant upped from scratch in a while.*
 
 ### Running PHP Unit Tests
 

--- a/_docs/sysadmin/installation/version_notes/v20.08.00.md
+++ b/_docs/sysadmin/installation/version_notes/v20.08.00.md
@@ -16,7 +16,7 @@ requires the following edits:
 
 1. Locate your `php.ini` file.
 
-   _It is probably something like `/etc/php/7.2/fpm/php.ini`._
+   _It is probably something like `/etc/php/8.1/fpm/php.ini`._
 
    Note: You can run this command to print your specific version of php:
 
@@ -32,7 +32,7 @@ requires the following edits:
 3. Restart php fpm:
 
    ```
-   sudo systemctl restart php7.2-fpm
+   sudo systemctl restart php8.1-fpm
    ```
 
    Or more generally:


### PR DESCRIPTION
It turns out that no one knows how to run the full php unit test suite and have it pass, so I investigated the php unit test instructions and Improved them. @lavalleeale has some changes at [https://github.com/Submitty/Submitty/pull/11802](url) to allow for the full suite to pass so these docs should match that.