### PR TITLE
[Bugfix:Developer] Fixed Migrations Page Typo

### DIFF
--- a/_docs/developer/development_instructions/migrations.md
+++ b/_docs/developer/development_instructions/migrations.md
@@ -24,7 +24,7 @@ own unique list of migrations. They are:
 * course
 
 Where `system` migrations should deal mainly with package installation/changes,
-system changes, new dependencies, etc. `master` migrations deals with changes to the master Submitty
+system changes, new dependencies, etc. `master` migrations deal with changes to the master Submitty
 database. `course` migrations are applied individually to each course
 detected in `/var/local/submitty/courses` and can be used to adjust the
 courses' DB, config files, etc.

--- a/_docs/developer/development_instructions/migrations.md
+++ b/_docs/developer/development_instructions/migrations.md
@@ -24,7 +24,7 @@ own unique list of migrations. They are:
 * course
 
 Where `system` migrations should deal mainly with package installation/changes,
-system changes, new dependencies, etc. `master` migraitons deals with changes to the master Submitty
+system changes, new dependencies, etc. `master` migrations deals with changes to the master Submitty
 database. `course` migrations are applied individually to each course
 detected in `/var/local/submitty/courses` and can be used to adjust the
 courses' DB, config files, etc.


### PR DESCRIPTION
Small typo I discovered while reading up on migrations.

Changed `migraitons` to `migrations`