### PR TITLE
[Documentation:Developer] Update JS lint intructions

### DIFF
--- a/_docs/developer/testing/linting_static_analysis.md
+++ b/_docs/developer/testing/linting_static_analysis.md
@@ -137,13 +137,13 @@ Alternatively, you can run eslint on your host system or on vagrant by navigatin
 directory and running:
 
 ```bash
-npm run eslint
+npx eslint
 ```
 
 To have eslint attempt to automatically fix any detected problems:
 
 ```bash
-npm run eslint:fix
+npx eslint:fix
 ```
 
 If you wish to lint or fix a specific file, you will need to run the eslint executable directly,


### PR DESCRIPTION
Right now running `npm eslint run` doesn't work for me, so I opened a pull request to fix that. This documentation PR updates the developer instructions to reflect this change.