### PR TITLE
Update PHP install instructions to use php8.2 packages

### DIFF
--- a/_docs/developer/testing/index.md
+++ b/_docs/developer/testing/index.md
@@ -66,7 +66,7 @@ pecl install xdebug
 For Ubuntu:
 
 ```bash
-sudo apt-get install php-cli php-mbstring php-xml php-xdebug php-curl php-zip php-sqlite3 composer
+sudo apt-get install php8.2-cli php8.2-mbstring php8.2-xml php8.2-xdebug php8.2-curl php8.2-zip php8.2-sqlite3 composer
 sudo apt-get install python3 python3-pip
 ```
 

--- a/_docs/developer/testing/install_php.md
+++ b/_docs/developer/testing/install_php.md
@@ -12,7 +12,7 @@ you will need to have PHP installed on your host machine first.
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y php php-curl php-xml php-mbstring 
+sudo apt-get install -y php8.2 php8.2-cli php8.2-curl php8.2-xml php8.2-mbstring 
 ```
 
 *You may need to install the PHP PPA for certain versions of PHP*

--- a/_docs/sysadmin/configuration/registration_feed.md
+++ b/_docs/sysadmin/configuration/registration_feed.md
@@ -100,7 +100,7 @@ However, these instructions will focus on Ubuntu server 20.04 which provides PHP
 
 1. If they haven't already been installed, install PHP and the required extensions.
 ```bash
-$ sudo apt-get install php php-pgsql
+$ sudo apt-get install php8.2 php8.2-pgsql
 ```
 2. Ensure the extensions are active.
 ```bash


### PR DESCRIPTION
Updated PHP installation commands to explicitly use php8.2 packages instead of generic php packages.
This ensures compatibility with current Ubuntu environments and avoids issues with missing or outdated default PHP versions.