### PR TITLE
[UI/UX:Developer] Add hover effect to sidebar navigation items

### DIFF
--- a/_sass/_colors.scss
+++ b/_sass/_colors.scss
@@ -10,6 +10,7 @@
   --nav-bg:            #f6fbfe;
   --nav-text:          #666666;
   --nav-selected:      #d9edf7;
+  --nav-hover:         #eef6fb;
   --brand-color:       #f6fbfe;
   --page-header:       #888888;  
   --inline-code-color: #393318;
@@ -30,6 +31,7 @@
   --nav-bg:            #202225;
   --nav-text:          #cccccc;
   --nav-selected:      #535353;
+  --nav-hover:         #3a3d42;
   --brand-color:       #000000;
   --page-header:       #999999;
   --inline-code-color: #FFFFFF;

--- a/_sass/_dark-mode.scss
+++ b/_sass/_dark-mode.scss
@@ -41,6 +41,10 @@ h4 {
     background-color: var(--nav-selected) !important;
 }
 
+#nav-tree .item:not(.selected):hover {
+    background-color: var(--nav-hover) !important;
+}
+
 #nav-tree .selected a {
     color: var(--content-color) !important;
     text-shadow: none !important;

--- a/navtree.css
+++ b/navtree.css
@@ -39,6 +39,10 @@
   text-shadow: 0px 1px 1px rgba(0, 0, 0, 0.25);
 }
 
+#nav-tree .item:not(.selected):hover {
+  background-color: var(--nav-hover, #eef6fb);
+}
+
 #nav-tree img {
   margin:0px;
   padding:0px;


### PR DESCRIPTION
Add a hover background color to sidebar navigation items in the nav tree to provide visual feedback when hovering over non-active items.

The hover color (`#eef6fb` light / `#3a3d42` dark) is intentionally lighter than the selected state color to maintain visual hierarchy between hovered and active items. Both light and dark themes are supported via CSS custom properties (`--nav-hover`) defined in `_colors.scss`, consistent with how the existing `--nav-selected` token works.

Changes:
- `navtree.css`: added `#nav-tree .item:not(.selected):hover` rule using `var(--nav-hover)`
- `_sass/_colors.scss`: added `--nav-hover` token for light and dark themes
- `_sass/_dark-mode.scss`: added hover rule with `!important` to override `navtree.css` in dark mode

Closes #12662 in https://github.com/Submitty/Submitty repository.
