### PR TITLE
[Documentation:Developer] Add Cypress npm update note

### DIFF
--- a/_docs/developer/testing/cypress.md
+++ b/_docs/developer/testing/cypress.md
@@ -18,11 +18,12 @@ Make sure you have [`node.js`](https://www.nodejs.org/)  version 10 or higher in
 # from the site directory
 npm install
 ```
-*NOTE: If you encounter issues launching Cypress, run `npm update` from the site directory.*
 
 If you are on Linux, view [this page](https://docs.cypress.io/guides/getting-started/installing-cypress.html#Linux) to see what dependencies you may need to install additionally for Cypress.
 
 If you are on WSL and run into an error, make sure you installed `node.js` on your desktop (Program Files) and not inside your local Submitty repository.
+
+*Note: If you encounter issues launching Cypress, run* `npm update` *from the site directory.* 
 
 ## Cypress Test Runner
 

--- a/_docs/developer/testing/cypress.md
+++ b/_docs/developer/testing/cypress.md
@@ -18,6 +18,7 @@ Make sure you have [`node.js`](https://www.nodejs.org/)  version 10 or higher in
 # from the site directory
 npm install
 ```
+*NOTE: If you encounter issues launching Cypress, run `npm update` from the site directory.*
 
 If you are on Linux, view [this page](https://docs.cypress.io/guides/getting-started/installing-cypress.html#Linux) to see what dependencies you may need to install additionally for Cypress.
 


### PR DESCRIPTION
**Why is this Change Important & Necessary?**

Some developers may encounter issues launching Cypress after installation. Adding a troubleshooting note provides a potential solution and can reduce confusion during setup.

**What is the New Behavior?**

A troubleshooting note has been added to the Cypress documentation recommending `npm update` if issues occur when launching Cypress.

**Automated Testing & Documentation**

Documentation update only.

**Other Information**

N/A

Screenshot:
<img width="959" height="500" alt="Screenshot 2026-06-10 103256" src="https://github.com/user-attachments/assets/f49bdd9d-89fd-45b7-bae8-13e75af2928d" />
