### PR TITLE
[Documentation:InstructorUI] 'Sub-Section' to 'Subsection' in docs

### DIFF
--- a/_docs/instructor/course_management/managing_enrollment.md
+++ b/_docs/instructor/course_management/managing_enrollment.md
@@ -116,7 +116,7 @@ See also [System Administrator instructions to enable Self Account Creation](/sy
 
     * "Registration Section": The registration section for the user, e.g. `2B`. Consists of up to 20 uppercase/lowercase letters 'A'-'Z'/'a'-'z', digits '0'-'9', underscores '_', or hyphens '-'.
 
-    * "Registration Sub-Section": The registration sub-section for the user, e.g. `team 7`. Consists of up to 20 uppercase/lowercase letters 'A'-'Z'/'a'-'z', digits '0'-'9', underscores '_', hyphens '-', or spaces ' '.
+    * "Registration Subsection": The registration subsection for the user, e.g. `team 7`. Consists of up to 20 uppercase/lowercase letters 'A'-'Z'/'a'-'z', digits '0'-'9', underscores '_', hyphens '-', or spaces ' '.
 
     * "Password": On versions of Submitty with password-based authentication, this can set the password for new users. Cannot be empty. Ignored for existing users, and versions of Submitty that don't use password authentication, including `submitty.cs.rpi.edu`.
 


### PR DESCRIPTION
The documentation for instructors about uploading Registration Subsections was inconsistently worded (The phrase Registration Sub-Section was used instead of Subsection). The documentation has now been updated to use the term 'Registration Subsection' in order to be consistent with the rest of Submitty.

Before:
<img width="1620" height="951" alt="image" src="https://github.com/user-attachments/assets/ff48b261-3dc4-4e08-b6ed-fd6f0b89a7ec" />

After:
<img width="1650" height="1080" alt="image" src="https://github.com/user-attachments/assets/2406b6c2-3671-4e5b-8dc2-acde769a5ee9" />
