### PR TITLE
[Documentation:Developer] from scratch worker install

### DIFF
--- a/_docs/developer/getting_started/worker_vm.md
+++ b/_docs/developer/getting_started/worker_vm.md
@@ -92,6 +92,24 @@ __NOTE__: Depending on the performance of your computer and the size of the auto
 
 ---
 
+## Removing Worker Machine(s)
+
+If you would like to remove your worker machine(s), run:
+```
+vagrant workers destroy
+```
+For each worker machine, you will be prompted on whether you would like to remove it.
+
+Alternatively, you can also destroy worker machines individually using:
+```
+vagrant destroy 1a2b3c4d
+```
+Where `1a2b3c4d` is the id of the machine.
+
+_Note: You can find a list of all vagrant machines and their ids using `vagrant global-status` ._
+
+---
+
 ## Manual Worker Installation (VirtualBox)
 
 1. Open the Virtual Box application.

--- a/_docs/developer/getting_started/worker_vm.md
+++ b/_docs/developer/getting_started/worker_vm.md
@@ -35,6 +35,18 @@ machines* in addition to your primary vagrant virtual machine.
    ```
    vagrant workers up
    ```
+   Alternatively, if you are testing the worker install process, it may be helpful to install the worker machine(s) from scratch.
+
+   On Linux or Mac type:
+   ```
+   FROM_SCRATCH=1 vagrant workers up
+   ```
+   On Windows with `cmd` type:
+   ```
+   SET FROM_SCRATCH=1
+   vagrant workers up
+   ```
+
    _NOTE: Do not use the --provider flag with this command, since it will conflict with the
    provider of the main virtual machine._
 


### PR DESCRIPTION
The developer instructions concerning the installation of worker VMs did not mention that it would be possible / situationally necessary to install the workers from scratch. I have added a note about this. I opted not to describe what the from scratch option actually does as it is documented in VM Install using Vagrant. 

Screenshot:
<img width="1920" height="951" alt="image" src="https://github.com/user-attachments/assets/fa3dcf5c-a8b9-4333-ae8c-a182cc0e4b8c" />

Additionally, I am also adding a note about how to remove the worker VMs, since there is nothing about that either. 

Screenshot:
<img width="1920" height="951" alt="image" src="https://github.com/user-attachments/assets/ae9752b7-e24f-4b18-8eb1-adf06dd2b52e" />
