### PR TITLE
[Documentation:Developer] Update php route info

### DIFF
--- a/_docs/developer/developing_the_php_site/controller.md
+++ b/_docs/developer/developing_the_php_site/controller.md
@@ -15,13 +15,12 @@ appropriate [View](view).
 A request to view the `UserDetails` page would first hit the
 `UserController`, which might look something like this:
 
-```PHP
+```php
 /**
-* Route to view the userDetailsPage.
-* @Route("/{_semester}/{_course}/show_user_details", methods={"GET"})
-* @AccessControl(role="INSTRUCTOR")
-**/
-
+ * Route to view the userDetailsPage.
+ */
+#[AccessControl(role="INSTRUCTOR")]
+#[Route("/{_semester}/{_course}/show_user_details", methods={"GET"})]
 public function userDetailsPage($user_id) {
    $user = $this->core->getQueries()->getUserFromId($user_id);
    if ($user) {
@@ -41,7 +40,7 @@ From the website, they can now make a request which routes to the
 `userDetails` page. Something like
 `f20/sample/show_user_details?user_id="aphacker"`
 
-Because we added `@AccessControl(role="INSTRUCTOR")`, only instructor
+Because we added `#[AccessControl(role="INSTRUCTOR")]`, only instructor
 level users can access this page.
 
 The `$user_id` parameter to our function is populated from the
@@ -86,9 +85,7 @@ annotation in the docstring for the controller class, like so:
 ```php
 use app\libraries\routers\Enabled;
 
-/**
- * @Enabled("forum")
- */
+#[Enabled(feature: "forum")]
 class ForumController {}
 ```
 

--- a/_docs/developer/software_and_system_design/router.md
+++ b/_docs/developer/software_and_system_design/router.md
@@ -30,44 +30,36 @@ While most routes in Submitty are specific to one course, there are places that 
 For those routes, it is simple to set up a route.
 
 ```php
-/**
- * @Route("/home")
- */
+#[Route("/home")]
 public function showHomepage() {...}
 ```
 
 #### Route with Course Information
 
-A majority of links in Submitty require course information to return correct contents. Therefore, it is necessary for the router to know which `(term, course)` tuple is requested. It is needed to prepend the route with `/courses/{_term}/{_course}`. The course information will be loaded automatically before calling the function.
+A majority of links in Submitty require course information to return correct contents. Therefore, it is necessary for the router to know which `(semester, course)` tuple is requested. It is needed to prepend the route with `/courses/{_semester}/{_course}`. The course information will be loaded automatically before calling the function.
 
 ```php
-/**
- * @Route("/courses/{_term}/{_course}/reports")
- */
+#[Route("/courses/{_semester}/{_course}/reports")]
 public function showReportPage() {...}
 ```
 
-To visit the page defined above, simply go to `{base_url}/{current term}/sample/reports`. 
+To visit the page defined above, simply go to `{base_url}/{current semester}/sample/reports`.
 
 #### Route with Parameters
 
 Sometimes we may want to pass parameters to functions. Wrapping the parameter name with brackets will do the trick.
 
 ```php
-/**
- * @Route("/courses/{_term}/{_course}/student/{gradeable_id}")
- */
-public function showHomeworkPage($gradeable_id){...}
+#[Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}")]
+public function showHomeworkPage($gradeable_id) {...}
 ```
 
-Note that `{_term}` and `{_course}` are actually special cases of parameters that are automatically processed by the router.
+Note that `{_semester}` and `{_course}` are actually special cases of parameters that are automatically processed by the router.
 
 Also, note that parameters in the `GET` query are passed to the function too without the need for explicit definition as long as parameter names are the same.
 
 ```php
-/**
- * @Route("/authentication/login")
- */
+#[Route("/authentication/login")]
 public function loginForm($old = null) {...}
 ```
 
@@ -78,16 +70,12 @@ The value of `$old` will be set to `Submitty` if you go to `/authentication/logi
 In some cases, you may want routes to match number-only parameters, or those not starting with certain words. This could be done by adding a `requirements` field in the route definition.
 
 ```php
-/**
- * @Route("/courses/{_term}/{_course}/notifications/{nid}", requirements={"nid": "[1-9]\d*"})
- */
-public function openNotification($nid) {...}
+#[Route("/courses/{_semester}/{_course}/notifications/{nid}", requirements: ["nid" => "[1-9]\d*"])]
+public function openNotification($nid, $seen) {...}
 ```
 
 ```php
-/**
- * @Route("/courses/{_term}/{_course}", requirements={"_term": "^(?!api)[^\/]+", "_course": "[^\/]+"})
- */
+#[Route('/courses/{_semester}/{_course}', requirements: ['_semester' => '^(?!api)[^\/]+', '_course' => '[^\/]+'])]
 public function navigationPage() {...}
 ```
 
@@ -98,27 +86,24 @@ To prevent [cross-site request forgery](https://en.wikipedia.org/wiki/Cross-site
 Note that, by default, the `methods` of routes are set to be `ALL`, which means the route accepts all kind of requests. Therefore, in some cases one route may be masked by another. If you have two routes with the same name, please specify the `methods` of both.
 
 ```php
-/**
- * @Route("/home/change_username", methods={"POST"})
- */
+#[Route("/user_profile/change_preferred_names", methods: ["POST"])]
 public function changeUserName(){...}
 ```
 
 #### Route that Needs Access Control
 
-Access control can be enforced easily via `@AccessControl` annotation. Please add `use app\libraries\routers\AccessControl` to the file before using it.
+Access control can be enforced easily via `#[AccessControl(...)]` annotation. Please add `use app\libraries\routers\AccessControl` to the file before using it.
 
 For example, the following route will only allow instructor access.
 
 ```php
-/**
- * @Route("/courses/{_term}/{_course}/course_materials/modify_permission")
- * @AccessControl(role="INSTRUCTOR")
- */
+
+#[AccessControl(role: "INSTRUCTOR")]
+#[Route("/courses/{_semester}/{_course}/course_materials/modify_timestamp")]
 public function modifyCourseMaterialsFilePermission($filename, $checked)
 ```
 
-For more examples about `@AccessControl`, please read [the documentation in the code](https://github.com/Submitty/Submitty/blob/master/site/app/libraries/routers/AccessControl.php).
+For more examples about `#[AccessControl(...)]`, please read [the documentation in the code](https://github.com/Submitty/Submitty/blob/master/site/app/libraries/routers/AccessControl.php).
 
 #### Route for API
 
@@ -130,20 +115,16 @@ Any route that uses the `/api` goes through a slightly different authentication 
 For example, the following route is the API for list of courses:
 
 ```php
-/**
- * @Route("/home/courses/new", methods={"POST"})
- * @Route("/api/courses", methods={"POST"})
- */
+#[Route("/home/courses/new", methods: ["POST"])]
+#[Route("/api/courses", methods: ["POST"])]
 public function createCourse()
 ```
 
 And an API route for a method within a course:
 
 ```php
-/**
- * @Route("/courses/{_term}/{_course}/users", methods={"GET"})
- * @Route("/api/courses/{_term}/{_course}/users", methods={"GET"})
- */
+#[Route("/courses/{_semester}/{_course}/users", methods: ["GET"])]
+#[Route("/api/courses/{_semester}/{_course}/users", methods: ["GET"])]
 public function getStudents()
 ```
 

--- a/_docs/developer/software_and_system_design/router.md
+++ b/_docs/developer/software_and_system_design/router.md
@@ -97,7 +97,6 @@ Access control can be enforced easily via `#[AccessControl(...)]` annotation. Pl
 For example, the following route will only allow instructor access.
 
 ```php
-
 #[AccessControl(role: "INSTRUCTOR")]
 #[Route("/courses/{_semester}/{_course}/course_materials/modify_timestamp")]
 public function modifyCourseMaterialsFilePermission($filename, $checked)

--- a/_docs/developer/software_and_system_design/router_response.md
+++ b/_docs/developer/software_and_system_design/router_response.md
@@ -19,10 +19,8 @@ like docstrings. You can think of PHP functions as endpoints that get
 mapped to different routes via the router.
 
 ```php
-/**
-* @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/team/new")
-*/
-public function createNewTeam($gradeable_id){
+#[Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/team/new")]
+public function createNewTeam($gradeable_id) {...}
 ```
 
 Above is an example route that points to a function in the
@@ -50,10 +48,8 @@ after the base-name matters.
 Functions can have multiple parameters sent to them through a URL.
 
 ```php
-/**
-* @Route("/courses/{_semester}/{_course}/example_route/{var1}/{var2}/{var3}")
-*/
- public function example($var1, $var2, $var3){
+#[Route("/courses/{_semester}/{_course}/example_route/{var1}/{var2}/{var3}")]
+ public function example($var1, $var2, $var3) {...}
 ```
 
 #### Pattern Matching Route Variables
@@ -73,10 +69,8 @@ request body. By adding `methods={""}` after the URL in a route annotation you
 can make sure the router matches certain types of requests only.
 
 ```php
-/**
- * @Route("/courses/{_semester}/{_course}/course_materials/upload", methods={"POST"})
- */
-public function ajaxUploadCourseMaterialsFiles() {
+#[Route("/courses/{_semester}/{_course}/course_materials/upload", methods: ["POST"])]
+public function ajaxUploadCourseMaterialsFiles() {...}
 ```
 
 The router will automatically check all POST requests for valid 
@@ -94,11 +88,9 @@ A PHP function can have multiple routes point towards it. This is
 typically done for optional parameters and the API.
 
 ```php
- /**
- * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}")
- * @Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/{gradeable_version}")
- */
- public function showHomeworkPage($gradeable_id, $gradeable_version = null){
+#[Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}")]
+#[Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/{gradeable_version}", requirements: ["gradeable_version" => "\d+"])]
+ public function showHomeworkPage($gradeable_id, $gradeable_version = null) {...}
 ```
 
 The above example allows users to optionally include a
@@ -106,7 +98,7 @@ gradeable_version in the URL while still calling the same function.
 
 #### Access Control
 
-The router can also restrict certain users by pattern matching against the user's access group. This can be done by adding the "\@AccessControl" annotation and giving a specific role. The following roles can be used
+The router can also restrict certain users by pattern matching against the user's access group. This can be done by adding the `#[AccessControl(...)]` annotation and giving a specific role. The following roles can be used
 in this annotation:
 
 * INSTRUCTOR
@@ -115,11 +107,9 @@ in this annotation:
 * STUDENT
 
 ```php
-/**
- * @Route("/courses/{_semester}/{_course}/course_materials/edit", methods={"POST"})
- * @AccessControl(role="INSTRUCTOR")
- */
-public function ajaxEditCourseMaterialsFiles() {
+#[AccessControl(role: "INSTRUCTOR")]
+#[Route("/courses/{_semester}/{_course}/course_materials/edit", methods: ["POST"])]
+public function ajaxEditCourseMaterialsFiles(bool $flush = true) {...}
 ```
 
 The above example will allow only users with the role "instructor"
@@ -131,18 +121,16 @@ You can also perform access control by restricting users with certain
 permissions. This can be done by passing in the "permission" field within the access control annotation. 
 
 ```php
-/**
- * @Route(/example/access)
- * @AccessControl(permission="path.read.rainbow_grades")
- */
-public function examplePermissionAccess(){
+#[AccessControl(permission="path.read.rainbow_grades")]
+#[Route(/example/access)]
+public function examplePermissionAccess() {...}
 ```
 
 The above access will allow only users with permission to view the 
 rainbow grades directory. You can view the list of permissions under
 [Access.php](https://github.com/Submitty/Submitty/blob/master/site/app/libraries/routers/AccessControl.php)
 
-*Note* You can restrict users by permission and role at the same time by using both parameters : `@AccessControl(role="STUDENT", permission="gradeable.submit.everyone")`
+*Note* You can restrict users by permission and role at the same time by using both parameters : `#[AccessControl(role="STUDENT", permission="gradeable.submit.everyone")]`
 
 
 Certain controllers can have every function restricted to a certain
@@ -150,11 +138,8 @@ role, for example the controllers under `site/app/controllers/admin`.
 You can annotate access across an entire class at once to prevent writing the same thing over every function.
 
 ```php
-/**
- * Class AdminGradeableController
- * @AccessControl(role="INSTRUCTOR")
- */
-class AdminGradeableController extends AbstractController {
+#[AccessControl(role: "INSTRUCTOR")]
+class AdminGradeableController extends AbstractController {...}
 ```
 
 Every function within `AdminGradeableController.php` will share this
@@ -173,11 +158,9 @@ behave very similarly as well.
 
 API routes always start with `/api/`. The following are examples of valid API routes.
 
-```php
-/**
-* @Route("/api/courses/{_semester}/{_course}/users", methods={"GET"})
-* @Route("/api/courses", methods={"POST"})
-*/
+```plaintext
+#[Route("/api/courses/{_semester}/{_course}/users", methods={"GET"})]
+#[Route("/api/courses", methods={"POST"})]
 ```
 
 #### Different Response Types
@@ -198,12 +181,13 @@ The API is currently a work in progress. Submitty uses a RESTful API design and 
 
 ## The MultiResponse Object
 
-Here is a basic example of the multiResponse object:
+Here is a basic example of the MultiResponse object:
 ```php
 /**
-* @Route("/example/method", methods={"GET"})
-* @Route("/api/example/method", methods={"GET"})
-*/
+ * @return MultiResponse
+ */
+#[Route("/example/method", methods={"GET"})]
+#[Route("/api/example/method", methods={"GET"})]
 public function foo(){
     return new MultiResponse(
         JsonResponse::getSuccessResponse("It worked!"),
@@ -313,4 +297,4 @@ https://submitty.myuniversity.edu/home/gradeables/foo/bar
 
 ### Using the MultiResponse Object
 
-It is recommended you use the MultiResponse object for new controllers moving onwards 
+It is recommended you use the MultiResponse object for new controllers moving onwards.


### PR DESCRIPTION
### Why is this Change Important & Necessary?

The documentation concerning Routes was outdated. The old syntax of `@Route(...)` is deprecated and in fact will no longer work with the recent update to the Route object we include from Symfony in [PR #12935](https://github.com/Submitty/Submitty/pull/12935).

### New Additions

Instances of `@Route(...)` have been replaced with `#[Route(...)]` to match what will be expected from developers when writing PHP code. 

### Screenshots

#### Before
1. Controller page:
<img width="1620" height="951" alt="image" src="https://github.com/user-attachments/assets/56bd84aa-f0b3-4d36-830d-c4eb84db370f" />

2. Excerpt from Router page:
<img width="1650" height="951" alt="image" src="https://github.com/user-attachments/assets/3e0d70db-0517-4689-b3ce-fa35475c18db" />

3. Excerpt from Routes and Responses page:
<img width="1650" height="951" alt="image" src="https://github.com/user-attachments/assets/2b041778-698f-41f2-9bff-2cdad0b06277" />


#### After
1. Updated Controller page:
<img width="1620" height="951" alt="image" src="https://github.com/user-attachments/assets/ad1a7dd4-530d-4cbf-b62c-98f81536a37a" />

2. Updated Router page:
<img width="1650" height="951" alt="image" src="https://github.com/user-attachments/assets/6f1cf287-8bc8-4818-b9e3-eb25bd490e3c" />

3. Updated Routes and Responses page:
<img width="1650" height="951" alt="image" src="https://github.com/user-attachments/assets/a7fe9db4-3feb-4ed6-819f-0099068da5b5" />


### Other information
Unfortunately, the markdown renderer thinks the #[Route(...)] syntax is a comment due to the leading #. If at some point GitHub pages updates their markdown renderer to allow for PHP 8 syntax highlighting then the Routes will appear correctly as uncommented. 
Example of how it is now:
<img width="437" height="319" alt="image" src="https://github.com/user-attachments/assets/5daab045-878e-4ef2-a165-faca83feeea4" />
Here is how it actually looks in the code:
<img width="503" height="321" alt="image" src="https://github.com/user-attachments/assets/87e875d8-c2cd-4ee8-82fe-5ad8107531a5" />

Notice how the routes are not italicized. 

This is not really a big deal but it kind of annoys me that the routes look like they are comments. However, I think that is better than rendering these code blocks as plain text or a different language than php (both of which would make the route appear 'correctly').

Also, the example given of UserController on the Controller / View pages is code that no longer exists in the submitty codebase. It is still a good example of how to write our php code but at some point we should probably update the example to use real code.



