### PR TITLE
[Documentation:Developer] Fixed PHPUnit Command Typo

### DIFF
--- a/_docs/developer/testing/php_unit_tests.md
+++ b/_docs/developer/testing/php_unit_tests.md
@@ -27,7 +27,7 @@ To run just an individual class or test, you can use the `--filter` flag on PHPU
 For example, to run the function `testInvalidProperty` would be
 `sudo -u submitty_php php vendor/bin/phpunit --filter testInvalidProperty` and running all
 of `AccessControlTester` would be
-`php vendor/bin/phpunit--filter AccessControlTester`. Be aware, filter
+`php vendor/bin/phpunit --filter AccessControlTester`. Be aware, filter
 can match against partial strings, so if you have two tests `testFoo` and `testFooBar`,
 running `--filter testFoo` will run them both. Alternatively, you can also directly run
 `phpunit` against a specific class by passing the path to the test class directly to


### PR DESCRIPTION
Added the missing space in this PHPUnit command example in the Running PHP Unit Tests page:
<img width="469" height="102" alt="Screenshot 2026-07-31 at 11 32 35 AM" src="https://github.com/user-attachments/assets/ad52dbe2-3ea8-45a9-9d1d-f62519c3cdfa" />
