### PR TITLE
[Documentation:TAGrading] Image Annotation Limits

### DIFF
--- a/_docs/grader/rubric_grading/image_annotation.md
+++ b/_docs/grader/rubric_grading/image_annotation.md
@@ -9,8 +9,8 @@ In addition to the somewhat general-purpose system of common marks and points,
 graders can leave more personalized type-written notes in the *Overall
 Comment* box at the bottom of the grading rubric panel.
 
-The grader can also add annotations to image documents that the
-student has submitted, or image documents that were automatically generated within
+The grader can also add annotations to image documents. 
+Currently image annotation is available for images that are automatically generated within
 the student's submission, such as the single-page JPGs made during a bulk-upload.
 Annotations can be handwritten using a touchscreen, digital tablet, or mouse,
 or they can be typewritten in textboxes places on the image.

--- a/_docs/grader/rubric_grading/image_annotation.md
+++ b/_docs/grader/rubric_grading/image_annotation.md
@@ -10,7 +10,7 @@ graders can leave more personalized type-written notes in the *Overall
 Comment* box at the bottom of the grading rubric panel.
 
 The grader can also add annotations to image documents. 
-Currently image annotation is available for images that are automatically generated within
+Currently image annotation is available for images that were automatically generated within
 the student's submission, such as the single-page JPGs made during a bulk-upload.
 Annotations can be handwritten using a touchscreen, digital tablet, or mouse,
 or they can be typewritten in textboxes places on the image.


### PR DESCRIPTION
**What problem are you trying to solve with Submitty**
Image annotation only works properly on auto-generated image files in submissions_processed, like the ones made during a bulk upload. This was only found out recently, and has been enforced in [PR#13121](https://github.com/Submitty/Submitty/pull/13121). This PR updates the documentation to reflect the behavior in that PR.

**Additional context**
As described in [Issue#13122](https://github.com/Submitty/Submitty/issues/13122), in the future we would like image annotation to work for any image submitted by the student, and once that has been implemented we can change the documentation back.