### PR TITLE
[Documentation:Developer] Use WSL Terminal to Run Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ If you have [Docker](https://www.docker.com/) installed, you do not need to inst
    ```
    The first run will take a few minutes to install dependencies.
 
+   * _NOTE: If you're on Windows, we recommend running this step in a WSL terminal, 
+     as using Command Prompt has been known to cause issues._
+
 3. Visit [http://localhost:4000](http://localhost:4000) to view the site.
    Changes to files will automatically trigger a rebuild and refresh your
    browser.


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Running "docker compose up" in a Windows Command Prompt terminal to run the documentation site locally has occasionally resulted in issues related to the "bundle install" step and failing to install Gemfiles.

### What is the New Behavior?
This PR adds a note recommending Windows developers run "docker compose up" in WSL rather than CMD.