### PR TITLE
[Documentation:Developer] add info for js unit testing

### DIFF
--- a/_docs/developer/testing/linting_static_analysis.md
+++ b/_docs/developer/testing/linting_static_analysis.md
@@ -135,6 +135,7 @@ bash .setup/SUBMITTY_TEST.sh <command> [options]
 - `php-lint`: Runs both PHP CodeSniffer and PHPStan (default options only).
 - `php-unit`: Runs PHP unit tests. [option: `--filter testFunctionName`, `--debug`]
 - `js-lint`: Runs eslint. [option: `--fix`]
+- `js-unit`: Runs the jest test suite. [option: `--api`]
 - `css-lint`: Runs stylelint. [option: `--fix`]
 - `py-flake8`: Runs flake8. [option: `/path/to/specific_file.py`]
 - `py-pylint`: Runs pylint. [option: `/path/to/specific_file.py`]
@@ -194,6 +195,17 @@ node_modules/.bin/eslint [--fix] <file>
 ```
 
 See also: [JavaScript Style Guide](/developer/coding_style_guide/javascript)
+
+## JavaScript Unit Testing
+
+The frontend JavaScript code for Submitty has unit tests utilizing a [jest](https://jestjs.io/) test suite.
+
+```bash
+submitty_test js-unit
+submitty_test js-unit --api
+```
+
+***NOTE:** For the -\-api option, Windows developers running commands on their host machine with CMD or Powershell may find that there are connection issues between the Docker container and the VM. In this case, instead running `submitty_test js-unit --api` in WSL or inside the VM should both still work.*
 
 ## CSS Linting
 


### PR DESCRIPTION
In Submitty PR [#13124](https://github.com/Submitty/Submitty/pull/13124), js unit testing was added for the submitty_test script. This PR adds documentation in the Linting / Static Analysis docs for developers.

<img width="943" height="763" alt="image" src="https://github.com/user-attachments/assets/6b507760-44c4-4534-902c-fe76bf2166fc" />
