### PR TITLE
[Documentation:System]  Adds example to get latest release

### DIFF
--- a/_docs/sysadmin/installation/update_submitty.md
+++ b/_docs/sysadmin/installation/update_submitty.md
@@ -22,8 +22,8 @@ Please also see [Update GNU/Linux Server](update_server) and [Installation Versi
 
     ```
     cd /usr/local/submitty/GIT_CHECKOUT/Submitty
-    git checkout master
-    git pull origin master
+    git checkout main
+    git pull origin main
     ```
 
 

--- a/_docs/sysadmin/installation/update_submitty.md
+++ b/_docs/sysadmin/installation/update_submitty.md
@@ -18,13 +18,19 @@ Please also see [Update GNU/Linux Server](update_server) and [Installation Versi
 ### Update Submitty Software to the latest Release
 
 1.  To update the Submitty source code repository, get the specific
-    branch/release to which you want to upgrade.  For example:
+    branch/release to which you want to upgrade.  For example, to update to the latest development version:
 
     ```
     cd /usr/local/submitty/GIT_CHECKOUT/Submitty
     git checkout main
     git pull origin main
     ```
+
+	Whereas to update to the latest release (changing `XX.yy.zz` for the right release tag):
+	```
+	git fetch origin --tags
+	git switch --detach vXX.yy.zz
+	```
 
 
 2.  Then re-install the Submitty source code.

--- a/_docs/sysadmin/installation/update_submitty.md
+++ b/_docs/sysadmin/installation/update_submitty.md
@@ -8,8 +8,8 @@ redirect_from:
 
 
 **IMPORTANT NOTE: If your system was initially installed prior to
-early June 2018, please start with the section at the bottom of this
-page.**
+early June 2018, please start [with the section at the bottom of this
+page](#installations-prior-to-early-june-2018).**
 
 
 Please also see [Update GNU/Linux Server](update_server) and [Installation Version Notes](version_notes).


### PR DESCRIPTION
Updates the branch name change from `master` to `main` and includes an example on how to update to a particular tag/release.

Additionally adds a in-page link to the section from the note to ease browsing of the documentation.